### PR TITLE
Refactor readonly mode to viewonly mode across the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This server uses the official MCP Python SDK and communicates via JSON-RPC over 
 - **MCP Resources**: Real-time cluster status and configuration information
 - **JSON-RPC Protocol**: Standard MCP communication over stdio
 - **Multi-Cluster Support**: Connect to up to 8 Kafka clusters simultaneously
-- **Per-Cluster READONLY Mode**: Individual readonly protection per cluster for production safety
+- **Per-Cluster VIEWONLY Mode**: Individual viewonly protection per cluster for production safety
 - **Cross-Cluster Operations**: Compare topics and consumer groups between clusters
 - **Authentication Support**: SASL/SSL authentication for secure Kafka connections
 - **confluent-kafka-python**: High-performance Kafka client library
@@ -49,8 +49,8 @@ Restart Claude Desktop and start asking about your Kafka clusters!
 ### Topic Management
 - `list_topics` - List all topics with metadata
 - `describe_topic` - Get detailed topic configuration and partition info
-- `create_topic` - Create new topics (if not readonly)
-- `delete_topic` - Delete topics (if not readonly)
+- `create_topic` - Create new topics (if not viewonly)
+- `delete_topic` - Delete topics (if not viewonly)
 
 ### Consumer Group Management
 - `list_consumer_groups` - List all consumer groups
@@ -70,7 +70,7 @@ Restart Claude Desktop and start asking about your Kafka clusters!
 ```bash
 export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
 export KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
-export READONLY="false"
+export VIEWONLY="false"
 ```
 
 ### Multi-Cluster Mode (Up to 8 clusters)
@@ -79,7 +79,7 @@ export READONLY="false"
 # Development cluster
 export KAFKA_CLUSTER_NAME_1="development"
 export KAFKA_BOOTSTRAP_SERVERS_1="dev-kafka:9092"
-export READONLY_1="false"
+export VIEWONLY_1="false"
 
 # Production cluster (with safety)
 export KAFKA_CLUSTER_NAME_2="production"  
@@ -88,7 +88,7 @@ export KAFKA_SECURITY_PROTOCOL_2="SASL_SSL"
 export KAFKA_SASL_MECHANISM_2="SCRAM-SHA-256"
 export KAFKA_SASL_USERNAME_2="prod-user"
 export KAFKA_SASL_PASSWORD_2="prod-password"
-export READONLY_2="true"
+export VIEWONLY_2="true"
 ```
 
 ## 🐳 Development Setup
@@ -125,9 +125,9 @@ Once connected to Claude Desktop:
 - "Show me all brokers in the production cluster"
 - "Compare topics between development and production clusters"
 
-## 🔒 READONLY Mode
+## 🔒 VIEWONLY Mode
 
-When `READONLY=true` is set, the MCP server blocks all modification operations:
+When `VIEWONLY=true` is set, the MCP server blocks all modification operations:
 
 **Blocked Operations:**
 - ❌ Topic creation and deletion
@@ -172,7 +172,9 @@ Following the same patterns as the kafka-schema-reg-mcp project:
 2. Create feature branch
 3. Add tests for new functionality
 4. Ensure all tests pass: `./tests/run_all_tests.sh`
-5. Submit pull request
+5. Update the README.md file with the new functionality.
+6. Fix formatting with `black` and `isort`.
+7. Submit pull request
 
 ## 📄 License
 

--- a/config-examples/README.md
+++ b/config-examples/README.md
@@ -16,7 +16,7 @@ This directory contains pre-configured Claude Desktop configuration examples for
 
 **`claude_desktop_multi_cluster_config.json`**
 - Supports multiple Kafka clusters (development + production)
-- Per-cluster readonly protection
+- Per-cluster viewonly protection
 - Different authentication methods per cluster
 - Perfect for DevOps teams
 
@@ -56,7 +56,7 @@ copy claude_desktop_stable_config.json %APPDATA%\Claude\claude_desktop_config.js
 | `KAFKA_SASL_MECHANISM` | SASL mechanism | (empty) | `SCRAM-SHA-256` |
 | `KAFKA_SASL_USERNAME` | SASL username | (empty) | `kafka-user` |
 | `KAFKA_SASL_PASSWORD` | SASL password | (empty) | `secret-password` |
-| `READONLY` | Enable readonly mode | `false` | `true` |
+| `VIEWONLY` | Enable viewonly mode | `false` | `true` |
 
 ### Multi-Cluster Mode
 
@@ -68,19 +68,19 @@ copy claude_desktop_stable_config.json %APPDATA%\Claude\claude_desktop_config.js
 | `KAFKA_SASL_MECHANISM_X` | SASL mechanism | `SCRAM-SHA-256` |
 | `KAFKA_SASL_USERNAME_X` | SASL username | `prod-user` |
 | `KAFKA_SASL_PASSWORD_X` | SASL password | `prod-password` |
-| `READONLY_X` | Per-cluster readonly | `true` |
+| `VIEWONLY_X` | Per-cluster viewonly | `true` |
 
 ## Security Best Practices
 
 ### Production Environment
-- Always use `READONLY=true` for production clusters
+- Always use `VIEWONLY=true` for production clusters
 - Use strong authentication (SASL/SSL)
 - Store credentials securely
 - Regularly rotate passwords
 
 ### Development Environment
 - Use separate dev clusters
-- Enable full access (`READONLY=false`)
+- Enable full access (`VIEWONLY=false`)
 - Use simple authentication for testing
 
 ## Troubleshooting

--- a/config-examples/claude_desktop_local_dev_config.json
+++ b/config-examples/claude_desktop_local_dev_config.json
@@ -8,7 +8,7 @@
       "env": {
         "KAFKA_BOOTSTRAP_SERVERS": "localhost:9092",
         "KAFKA_SECURITY_PROTOCOL": "PLAINTEXT",
-        "READONLY": "false"
+        "VIEWONLY": "false"
       },
       "cwd": "/path/to/kafka-brokers-mcp"
     }

--- a/config-examples/claude_desktop_multi_cluster_config.json
+++ b/config-examples/claude_desktop_multi_cluster_config.json
@@ -10,28 +10,28 @@
         "-e", "KAFKA_CLUSTER_NAME_1",
         "-e", "KAFKA_BOOTSTRAP_SERVERS_1",
         "-e", "KAFKA_SECURITY_PROTOCOL_1",
-        "-e", "READONLY_1",
+        "-e", "VIEWONLY_1",
         "-e", "KAFKA_CLUSTER_NAME_2",
         "-e", "KAFKA_BOOTSTRAP_SERVERS_2",
         "-e", "KAFKA_SECURITY_PROTOCOL_2",
         "-e", "KAFKA_SASL_MECHANISM_2",
         "-e", "KAFKA_SASL_USERNAME_2",
         "-e", "KAFKA_SASL_PASSWORD_2",
-        "-e", "READONLY_2",
+        "-e", "VIEWONLY_2",
         "aywengo/kafka-brokers-mcp:stable"
       ],
       "env": {
         "KAFKA_CLUSTER_NAME_1": "development",
         "KAFKA_BOOTSTRAP_SERVERS_1": "localhost:9092",
         "KAFKA_SECURITY_PROTOCOL_1": "PLAINTEXT",
-        "READONLY_1": "false",
+        "VIEWONLY_1": "false",
         "KAFKA_CLUSTER_NAME_2": "production",
         "KAFKA_BOOTSTRAP_SERVERS_2": "prod-kafka:9092",
         "KAFKA_SECURITY_PROTOCOL_2": "SASL_SSL",
         "KAFKA_SASL_MECHANISM_2": "SCRAM-SHA-256",
         "KAFKA_SASL_USERNAME_2": "prod-user",
         "KAFKA_SASL_PASSWORD_2": "prod-password",
-        "READONLY_2": "true"
+        "VIEWONLY_2": "true"
       }
     }
   }

--- a/config-examples/claude_desktop_stable_config.json
+++ b/config-examples/claude_desktop_stable_config.json
@@ -12,13 +12,13 @@
         "-e", "KAFKA_SASL_MECHANISM",
         "-e", "KAFKA_SASL_USERNAME",
         "-e", "KAFKA_SASL_PASSWORD",
-        "-e", "READONLY",
+        "-e", "VIEWONLY",
         "aywengo/kafka-brokers-mcp:stable"
       ],
       "env": {
         "KAFKA_BOOTSTRAP_SERVERS": "localhost:9092",
         "KAFKA_SECURITY_PROTOCOL": "PLAINTEXT",
-        "READONLY": "false"
+        "VIEWONLY": "false"
       }
     }
   }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,7 +16,7 @@ Provides real-time cluster status information.
     "default": {
       "name": "default",
       "bootstrap_servers": "localhost:9092",
-      "readonly": false,
+      "viewonly": false,
       "topics_count": 5,
       "brokers_count": 1,
       "status": "healthy"
@@ -40,7 +40,7 @@ Provides detailed cluster configuration information.
       "name": "default",
       "bootstrap_servers": "localhost:9092",
       "security_protocol": "PLAINTEXT",
-      "readonly": false,
+      "viewonly": false,
       "authentication": {
         "sasl_mechanism": null,
         "has_credentials": false
@@ -48,7 +48,7 @@ Provides detailed cluster configuration information.
     }
   },
   "configuration": {
-    "readonly_protection": false,
+    "viewonly_protection": false,
     "multi_cluster_mode": false,
     "total_clusters": 1
   }
@@ -72,7 +72,7 @@ Lists all configured Kafka clusters with their status.
     "name": "development",
     "bootstrap_servers": "localhost:9092",
     "security_protocol": "PLAINTEXT",
-    "readonly": false,
+    "viewonly": false,
     "topics_count": 3,
     "brokers_count": 1,
     "status": "healthy"
@@ -81,7 +81,7 @@ Lists all configured Kafka clusters with their status.
     "name": "production",
     "bootstrap_servers": "prod-kafka:9092",
     "security_protocol": "SASL_SSL",
-    "readonly": true,
+    "viewonly": true,
     "topics_count": 15,
     "brokers_count": 3,
     "status": "healthy"
@@ -274,7 +274,7 @@ Provides comprehensive cluster metadata and statistics.
 {
   "cluster_name": "production",
   "bootstrap_servers": "prod-kafka:9092",
-  "readonly": true,
+          "viewonly": true,
   "cluster_id": "kafka-cluster-prod",
   "controller_id": 1,
   "brokers": {
@@ -319,9 +319,9 @@ raise ValueError("Consumer group 'missing-group' not found")
 }
 ```
 
-### Readonly Mode Protection
+### Viewonly Mode Protection
 
-When a cluster is in readonly mode, certain operations are blocked:
+When a cluster is in viewonly mode, certain operations are blocked:
 
 **Blocked Operations:**
 - Topic creation/deletion
@@ -370,7 +370,7 @@ Supports up to 8 clusters with independent configurations:
 export KAFKA_CLUSTER_NAME_1="development"
 export KAFKA_BOOTSTRAP_SERVERS_1="dev-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL_1="PLAINTEXT"
-export READONLY_1="false"
+export VIEWONLY_1="false"
 
 # Cluster 2 - Production
 export KAFKA_CLUSTER_NAME_2="production"
@@ -379,7 +379,7 @@ export KAFKA_SECURITY_PROTOCOL_2="SASL_SSL"
 export KAFKA_SASL_MECHANISM_2="SCRAM-SHA-256"
 export KAFKA_SASL_USERNAME_2="prod-user"
 export KAFKA_SASL_PASSWORD_2="prod-password"
-export READONLY_2="true"
+export VIEWONLY_2="true"
 ```
 
 ## Performance Considerations

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,7 +14,7 @@ docker pull aywengo/kafka-brokers-mcp:stable
 docker run -d \
   -e KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KAFKA_SECURITY_PROTOCOL=PLAINTEXT \
-  -e READONLY=false \
+  -e VIEWONLY=false \
   aywengo/kafka-brokers-mcp:stable
 ```
 
@@ -29,7 +29,7 @@ pip install -r requirements.txt
 # Configure environment
 export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
 export KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
-export READONLY="false"
+export VIEWONLY="false"
 
 # Run the server
 python kafka_brokers_unified_mcp.py
@@ -54,7 +54,7 @@ services:
       - KAFKA_CLUSTER_NAME_1=development
       - KAFKA_BOOTSTRAP_SERVERS_1=dev-kafka:9092
       - KAFKA_SECURITY_PROTOCOL_1=PLAINTEXT
-      - READONLY_1=false
+      - VIEWONLY_1=false
       
       - KAFKA_CLUSTER_NAME_2=production
       - KAFKA_BOOTSTRAP_SERVERS_2=prod-kafka:9092
@@ -62,7 +62,7 @@ services:
       - KAFKA_SASL_MECHANISM_2=SCRAM-SHA-256
       - KAFKA_SASL_USERNAME_2=prod-user
       - KAFKA_SASL_PASSWORD_2=${PROD_KAFKA_PASSWORD}
-      - READONLY_2=true
+      - VIEWONLY_2=true
     ports:
       - "38001:8000"
     healthcheck:
@@ -128,7 +128,7 @@ spec:
             secretKeyRef:
               name: kafka-credentials
               key: password
-        - name: READONLY
+        - name: VIEWONLY
           value: "true"
         resources:
           requests:
@@ -205,7 +205,7 @@ kafka:
       bootstrapServers: prod-kafka:9092
       securityProtocol: SASL_SSL
       saslMechanism: SCRAM-SHA-256
-      readonly: true
+                    viewonly: true
       credentials:
         existingSecret: kafka-prod-credentials
         usernameKey: username
@@ -263,7 +263,7 @@ healthCheck:
           "value": "SASL_SSL"
         },
         {
-          "name": "READONLY",
+                          "name": "VIEWONLY",
           "value": "true"
         }
       ],
@@ -307,7 +307,7 @@ gcloud run deploy kafka-brokers-mcp \
   --image=aywengo/kafka-brokers-mcp:stable \
   --platform=managed \
   --region=us-central1 \
-  --set-env-vars="KAFKA_BOOTSTRAP_SERVERS=kafka-cluster:9092,KAFKA_SECURITY_PROTOCOL=SASL_SSL,READONLY=true" \
+  --set-env-vars="KAFKA_BOOTSTRAP_SERVERS=kafka-cluster:9092,KAFKA_SECURITY_PROTOCOL=SASL_SSL,VIEWONLY=true" \
   --set-secrets="KAFKA_SASL_USERNAME=kafka-username:latest,KAFKA_SASL_PASSWORD=kafka-password:latest" \
   --port=8000 \
   --memory=1Gi \
@@ -335,7 +335,7 @@ properties:
         value: kafka-cluster.eastus.cloudapp.azure.com:9092
       - name: KAFKA_SECURITY_PROTOCOL
         value: SASL_SSL
-      - name: READONLY
+      - name: VIEWONLY
         value: "true"
       - name: KAFKA_SASL_USERNAME
         secureValue: "{{kafka-username}}"

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -38,16 +38,16 @@ The Kafka Brokers MCP Server enables natural language interaction with Kafka clu
 # Multi-cluster setup for ops team
 export KAFKA_CLUSTER_NAME_1="development"
 export KAFKA_BOOTSTRAP_SERVERS_1="dev-kafka:9092"
-export READONLY_1="false"
+export VIEWONLY_1="false"
 
 export KAFKA_CLUSTER_NAME_2="staging"
 export KAFKA_BOOTSTRAP_SERVERS_2="staging-kafka:9092" 
-export READONLY_2="false"
+export VIEWONLY_2="false"
 
 export KAFKA_CLUSTER_NAME_3="production"
 export KAFKA_BOOTSTRAP_SERVERS_3="prod-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL_3="SASL_SSL"
-export READONLY_3="true"  # Production safety
+export VIEWONLY_3="true"  # Production safety
 ```
 
 ### 2. Development and Debugging
@@ -159,7 +159,7 @@ export KAFKA_BOOTSTRAP_SERVERS_2="analytics-kafka:9092"
 # High-security configuration
 export KAFKA_SECURITY_PROTOCOL="SASL_SSL"
 export KAFKA_SASL_MECHANISM="SCRAM-SHA-256"
-export READONLY="true"  # Read-only for compliance
+export VIEWONLY="true"  # Read-only for compliance
 ```
 
 **Common Prompts**:
@@ -210,18 +210,18 @@ export KAFKA_BOOTSTRAP_SERVERS_2="analytics-kafka:9092"
 # Development
 export KAFKA_CLUSTER_NAME_1="dev"
 export KAFKA_BOOTSTRAP_SERVERS_1="dev-kafka:9092"
-export READONLY_1="false"
+export VIEWONLY_1="false"
 
 # Staging
 export KAFKA_CLUSTER_NAME_2="staging"
 export KAFKA_BOOTSTRAP_SERVERS_2="staging-kafka:9092"
-export READONLY_2="false"
+export VIEWONLY_2="false"
 
 # Production
 export KAFKA_CLUSTER_NAME_3="prod"
 export KAFKA_BOOTSTRAP_SERVERS_3="prod-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL_3="SASL_SSL"
-export READONLY_3="true"
+export VIEWONLY_3="true"
 ```
 
 **Claude Prompts**:
@@ -291,9 +291,9 @@ curl -X POST "http://kafka-brokers-mcp:8000" \
 
 ### Security
 
-1. **Readonly Mode for Production**:
+1. **Viewonly Mode for Production**:
    ```bash
-   export READONLY="true"  # Prevent accidental modifications
+   export VIEWONLY="true"  # Prevent accidental modifications
    ```
 
 2. **Secure Authentication**:
@@ -311,7 +311,7 @@ curl -X POST "http://kafka-brokers-mcp:8000" \
 1. **Multi-Cluster Setup**:
    - Separate development, staging, and production clusters
    - Use descriptive cluster names
-   - Apply appropriate readonly settings
+   - Apply appropriate viewonly settings
 
 2. **Monitoring Strategy**:
    - Regular health checks via Claude prompts
@@ -362,7 +362,7 @@ curl -X POST "http://kafka-brokers-mcp:8000" \
 # Single cluster for development
 export KAFKA_BOOTSTRAP_SERVERS="dev-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
-export READONLY="false"
+export VIEWONLY="false"
 ```
 
 ### Operations Team Setup
@@ -371,12 +371,12 @@ export READONLY="false"
 export KAFKA_CLUSTER_NAME_1="production-us-east"
 export KAFKA_BOOTSTRAP_SERVERS_1="prod-east-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL_1="SASL_SSL"
-export READONLY_1="true"
+export VIEWONLY_1="true"
 
 export KAFKA_CLUSTER_NAME_2="production-us-west"
 export KAFKA_BOOTSTRAP_SERVERS_2="prod-west-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL_2="SASL_SSL"
-export READONLY_2="true"
+export VIEWONLY_2="true"
 ```
 
 ### Analytics Team Setup
@@ -385,7 +385,7 @@ export READONLY_2="true"
 export KAFKA_BOOTSTRAP_SERVERS="analytics-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL="SASL_PLAINTEXT"
 export KAFKA_SASL_MECHANISM="SCRAM-SHA-256"
-export READONLY="true"  # Read-only access for analysts
+export VIEWONLY="true"  # Read-only access for analysts
 ```
 
 This comprehensive use case guide demonstrates the versatility and power of the Kafka Brokers MCP Server across different roles, industries, and operational scenarios.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,7 +32,7 @@ Available Clusters:
     "name": "development",
     "bootstrap_servers": "localhost:9092",
     "security_protocol": "PLAINTEXT",
-    "readonly": false,
+    "viewonly": false,
     "topics_count": 8,
     "brokers_count": 1,
     "status": "healthy"
@@ -71,7 +71,7 @@ python scripts/create_test_data.py production
 - **Sample Messages**: Realistic JSON messages for each topic type
 
 **Features**:
-- Respects readonly mode settings
+- Respects viewonly mode settings
 - Configurable partition counts and retention policies
 - Produces realistic sample data
 - Creates consumer groups with different consumption patterns
@@ -85,19 +85,19 @@ Both scripts use the same environment configuration as the main MCP server:
 ```bash
 export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
 export KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
-export READONLY="false"
+export VIEWONLY="false"
 ```
 
 ### Multi-Cluster
 ```bash
 export KAFKA_CLUSTER_NAME_1="development"
 export KAFKA_BOOTSTRAP_SERVERS_1="dev-kafka:9092"
-export READONLY_1="false"
+export VIEWONLY_1="false"
 
 export KAFKA_CLUSTER_NAME_2="production"
 export KAFKA_BOOTSTRAP_SERVERS_2="prod-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL_2="SASL_SSL"
-export READONLY_2="true"
+export VIEWONLY_2="true"
 ```
 
 ## Development Workflow
@@ -114,7 +114,7 @@ cd tests
 # Configure for test environment
 export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
 export KAFKA_SECURITY_PROTOCOL="PLAINTEXT"
-export READONLY="false"
+export VIEWONLY="false"
 
 # Create sample data
 python scripts/create_test_data.py
@@ -173,13 +173,13 @@ python scripts/test_mcp_tools.py
 ### Production Validation
 
 ```bash
-# Test against production (readonly)
+# Test against production (viewonly)
 export KAFKA_BOOTSTRAP_SERVERS="prod-kafka:9092"
 export KAFKA_SECURITY_PROTOCOL="SASL_SSL"
 export KAFKA_SASL_MECHANISM="SCRAM-SHA-256"
-export KAFKA_SASL_USERNAME="readonly-user"
+export KAFKA_SASL_USERNAME="viewonly-user"
 export KAFKA_SASL_PASSWORD="password"
-export READONLY="true"
+export VIEWONLY="true"
 
 python scripts/test_mcp_tools.py
 ```
@@ -214,7 +214,7 @@ python scripts/create_test_data.py staging
 ```
 
 **Safety Features**:
-- Warns if cluster is in readonly mode
+- Warns if cluster is in viewonly mode
 - Checks for existing topics before creation
 - Validates cluster connectivity before proceeding
 
@@ -295,7 +295,7 @@ When adding new scripts:
 ## Best Practices
 
 1. **Always test locally first** before running against production
-2. **Use readonly mode** for production environments
+2. **Use viewonly mode** for production environments
 3. **Validate environment** configuration before running scripts
 4. **Check connectivity** before creating resources
 5. **Clean up test data** when no longer needed

--- a/scripts/create_test_data.py
+++ b/scripts/create_test_data.py
@@ -281,9 +281,9 @@ def main():
 
     print(f"Using cluster: {cluster_name} ({cluster_config.bootstrap_servers})")
 
-    # Check readonly mode
-    if cluster_config.readonly:
-        print(f"⚠️  Cluster '{cluster_name}' is in readonly mode!")
+    # Check viewonly mode
+    if cluster_config.viewonly:
+        print(f"⚠️  Cluster '{cluster_name}' is in viewonly mode!")
         response = input("Continue anyway? (y/N): ")
         if response.lower() != "y":
             print("Aborted")

--- a/scripts/test_mcp_tools.py
+++ b/scripts/test_mcp_tools.py
@@ -174,7 +174,7 @@ def check_environment():
     if single_cluster:
         print(f"Single cluster mode detected: {single_cluster}")
         print(f"Security protocol: {os.getenv('KAFKA_SECURITY_PROTOCOL', 'PLAINTEXT')}")
-        print(f"Readonly mode: {os.getenv('READONLY', 'false')}")
+        print(f"Viewonly mode: {os.getenv('VIEWONLY', 'false')}")
         return True
 
     # Check for multi-cluster configuration
@@ -185,8 +185,8 @@ def check_environment():
         if name and servers:
             cluster_count += 1
             print(f"Cluster {i}: {name} -> {servers}")
-            readonly = os.getenv(f"READONLY_{i}", "false")
-            print(f"  Readonly: {readonly}")
+            viewonly = os.getenv(f"VIEWONLY_{i}", "false")
+            print(f"  Viewonly: {viewonly}")
 
     if cluster_count > 0:
         print(f"\nMulti-cluster mode detected: {cluster_count} clusters")
@@ -267,12 +267,12 @@ def main():
         print("  Single cluster:")
         print("    KAFKA_BOOTSTRAP_SERVERS - Kafka broker endpoints")
         print("    KAFKA_SECURITY_PROTOCOL - Security protocol (default: PLAINTEXT)")
-        print("    READONLY - Enable readonly mode (default: false)")
+        print("    VIEWONLY - Enable viewonly mode (default: false)")
         print("")
         print("  Multi-cluster:")
         print("    KAFKA_CLUSTER_NAME_X - Cluster name (X=1-8)")
         print("    KAFKA_BOOTSTRAP_SERVERS_X - Cluster endpoints")
-        print("    READONLY_X - Per-cluster readonly mode")
+        print("    VIEWONLY_X - Per-cluster viewonly mode")
         return
 
     try:

--- a/tests/run_single_test.py
+++ b/tests/run_single_test.py
@@ -14,18 +14,18 @@ def setup_test_environment():
     test_env = {
         'KAFKA_BOOTSTRAP_SERVERS': 'localhost:9092',
         'KAFKA_SECURITY_PROTOCOL': 'PLAINTEXT', 
-        'READONLY': 'false',
+        'VIEWONLY': 'false',
         
         # Multi-cluster configuration for comprehensive tests
         'KAFKA_CLUSTER_NAME_1': 'dev',
         'KAFKA_BOOTSTRAP_SERVERS_1': 'localhost:9092',
         'KAFKA_SECURITY_PROTOCOL_1': 'PLAINTEXT',
-        'READONLY_1': 'false',
+        'VIEWONLY_1': 'false',
         
         'KAFKA_CLUSTER_NAME_2': 'prod', 
         'KAFKA_BOOTSTRAP_SERVERS_2': 'localhost:39093',
         'KAFKA_SECURITY_PROTOCOL_2': 'PLAINTEXT',
-        'READONLY_2': 'false'
+        'VIEWONLY_2': 'false'
     }
     
     for key, value in test_env.items():

--- a/tests/test_basic_server.py
+++ b/tests/test_basic_server.py
@@ -34,7 +34,7 @@ class TestKafkaClusterManager:
         with patch.dict(os.environ, {
             'KAFKA_BOOTSTRAP_SERVERS': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL': 'PLAINTEXT',
-            'READONLY': 'false'
+            'VIEWONLY': 'false'
         }, clear=True):
             manager = load_cluster_configurations()
             
@@ -45,7 +45,7 @@ class TestKafkaClusterManager:
             assert config.name == 'default'
             assert config.bootstrap_servers == 'localhost:9092'
             assert config.security_protocol == 'PLAINTEXT'
-            assert config.readonly is False
+            assert config.viewonly is False
     
     def test_multi_cluster_config(self):
         """Test multi-cluster configuration loading."""
@@ -53,14 +53,14 @@ class TestKafkaClusterManager:
             'KAFKA_CLUSTER_NAME_1': 'dev',
             'KAFKA_BOOTSTRAP_SERVERS_1': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL_1': 'PLAINTEXT',
-            'READONLY_1': 'false',
+            'VIEWONLY_1': 'false',
             'KAFKA_CLUSTER_NAME_2': 'prod',
             'KAFKA_BOOTSTRAP_SERVERS_2': 'localhost:9093',
             'KAFKA_SECURITY_PROTOCOL_2': 'SASL_SSL',
             'KAFKA_SASL_MECHANISM_2': 'SCRAM-SHA-256',
             'KAFKA_SASL_USERNAME_2': 'prod-user',
             'KAFKA_SASL_PASSWORD_2': 'prod-pass',
-            'READONLY_2': 'true'
+            'VIEWONLY_2': 'true'
         }, clear=True):
             manager = load_cluster_configurations()
             
@@ -71,7 +71,7 @@ class TestKafkaClusterManager:
             dev_config = manager.get_cluster_config('dev')
             assert dev_config.name == 'dev'
             assert dev_config.bootstrap_servers == 'localhost:9092'
-            assert dev_config.readonly is False
+            assert dev_config.viewonly is False
             
             prod_config = manager.get_cluster_config('prod')
             assert prod_config.name == 'prod'
@@ -79,7 +79,7 @@ class TestKafkaClusterManager:
             assert prod_config.security_protocol == 'SASL_SSL'
             assert prod_config.sasl_mechanism == 'SCRAM-SHA-256'
             assert prod_config.sasl_username == 'prod-user'
-            assert prod_config.readonly is True
+            assert prod_config.viewonly is True
     
     def test_no_config_raises_error(self):
         """Test that missing configuration raises appropriate error."""
@@ -87,17 +87,17 @@ class TestKafkaClusterManager:
             with pytest.raises(ValueError, match="No cluster configurations found"):
                 load_cluster_configurations()
     
-    def test_readonly_check(self):
-        """Test readonly mode checking."""
+    def test_viewonly_check(self):
+        """Test viewonly mode checking."""
         config = KafkaClusterConfig(
             name='test',
             bootstrap_servers='localhost:9092',
-            readonly=True
+            viewonly=True
         )
         manager = KafkaClusterManager()
         manager.add_cluster(config)
         
-        assert manager.is_readonly('test') is True
+        assert manager.is_viewonly('test') is True
 
 class TestMCPServerIntegration:
     """Integration tests with actual Kafka clusters."""
@@ -124,7 +124,7 @@ class TestMCPServerIntegration:
         self.env_patch = patch.dict(os.environ, {
             'KAFKA_BOOTSTRAP_SERVERS': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL': 'PLAINTEXT',
-            'READONLY': 'false'
+            'VIEWONLY': 'false'
         })
         self.env_patch.start()
         
@@ -253,42 +253,42 @@ class TestMCPServerIntegration:
         assert config.bootstrap_servers == 'localhost:9092'
         assert config.security_protocol == 'PLAINTEXT'
 
-class TestReadonlyMode:
-    """Test readonly mode functionality."""
+class TestViewonlyMode:
+    """Test viewonly mode functionality."""
     
-    def test_readonly_flag_detection(self):
-        """Test that readonly flag is properly detected."""
+    def test_viewonly_flag_detection(self):
+        """Test that viewonly flag is properly detected."""
         config = KafkaClusterConfig(
-            name='readonly-cluster',
+            name='viewonly-cluster',
             bootstrap_servers='localhost:9092',
-            readonly=True
+            viewonly=True
         )
         
         manager = KafkaClusterManager()
         manager.add_cluster(config)
         
-        assert manager.is_readonly('readonly-cluster') is True
+        assert manager.is_viewonly('viewonly-cluster') is True
     
-    def test_multi_cluster_readonly_modes(self):
-        """Test different readonly modes across clusters."""
+    def test_multi_cluster_viewonly_modes(self):
+        """Test different viewonly modes across clusters."""
         dev_config = KafkaClusterConfig(
             name='dev',
             bootstrap_servers='localhost:9092',
-            readonly=False
+            viewonly=False
         )
         
         prod_config = KafkaClusterConfig(
             name='prod',
             bootstrap_servers='localhost:9093',
-            readonly=True
+            viewonly=True
         )
         
         manager = KafkaClusterManager()
         manager.add_cluster(dev_config)
         manager.add_cluster(prod_config)
         
-        assert manager.is_readonly('dev') is False
-        assert manager.is_readonly('prod') is True
+        assert manager.is_viewonly('dev') is False
+        assert manager.is_viewonly('prod') is True
 
 class TestErrorHandling:
     """Test error handling scenarios."""

--- a/tests/test_consumer_group_operations.py
+++ b/tests/test_consumer_group_operations.py
@@ -46,7 +46,7 @@ class TestConsumerGroupOperations:
         self.env_patch = patch.dict(os.environ, {
             'KAFKA_BOOTSTRAP_SERVERS': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL': 'PLAINTEXT',
-            'READONLY': 'false'
+            'VIEWONLY': 'false'
         })
         self.env_patch.start()
         
@@ -235,7 +235,7 @@ class TestConsumerGroupOffsets:
         self.env_patch = patch.dict(os.environ, {
             'KAFKA_BOOTSTRAP_SERVERS': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL': 'PLAINTEXT',
-            'READONLY': 'false'
+            'VIEWONLY': 'false'
         })
         self.env_patch.start()
         self.manager = load_cluster_configurations()

--- a/tests/test_multi_cluster_mcp.py
+++ b/tests/test_multi_cluster_mcp.py
@@ -31,7 +31,7 @@ class TestMultiClusterConfiguration:
             'KAFKA_CLUSTER_NAME_1': 'development',
             'KAFKA_BOOTSTRAP_SERVERS_1': 'dev-kafka:9092',
             'KAFKA_SECURITY_PROTOCOL_1': 'PLAINTEXT',
-            'READONLY_1': 'false',
+            'VIEWONLY_1': 'false',
             
             'KAFKA_CLUSTER_NAME_2': 'staging',
             'KAFKA_BOOTSTRAP_SERVERS_2': 'staging-kafka:9092',
@@ -39,7 +39,7 @@ class TestMultiClusterConfiguration:
             'KAFKA_SASL_MECHANISM_2': 'PLAIN',
             'KAFKA_SASL_USERNAME_2': 'staging-user',
             'KAFKA_SASL_PASSWORD_2': 'staging-password',
-            'READONLY_2': 'false',
+            'VIEWONLY_2': 'false',
             
             'KAFKA_CLUSTER_NAME_3': 'production',
             'KAFKA_BOOTSTRAP_SERVERS_3': 'prod-kafka:9092',
@@ -47,7 +47,7 @@ class TestMultiClusterConfiguration:
             'KAFKA_SASL_MECHANISM_3': 'SCRAM-SHA-256',
             'KAFKA_SASL_USERNAME_3': 'prod-user',
             'KAFKA_SASL_PASSWORD_3': 'prod-password',
-            'READONLY_3': 'true',
+            'VIEWONLY_3': 'true',
         }, clear=True):
             manager = load_cluster_configurations()
             
@@ -59,14 +59,14 @@ class TestMultiClusterConfiguration:
             assert dev_config.name == 'development'
             assert dev_config.bootstrap_servers == 'dev-kafka:9092'
             assert dev_config.security_protocol == 'PLAINTEXT'
-            assert dev_config.readonly is False
+            assert dev_config.viewonly is False
             
             staging_config = manager.get_cluster_config('staging')
             assert staging_config.name == 'staging'
             assert staging_config.bootstrap_servers == 'staging-kafka:9092'
             assert staging_config.security_protocol == 'SASL_PLAINTEXT'
             assert staging_config.sasl_mechanism == 'PLAIN'
-            assert staging_config.readonly is False
+            assert staging_config.viewonly is False
             
             prod_config = manager.get_cluster_config('production')
             assert prod_config.name == 'production'
@@ -75,7 +75,7 @@ class TestMultiClusterConfiguration:
             assert prod_config.sasl_mechanism == 'SCRAM-SHA-256'
             assert prod_config.sasl_username == 'prod-user'
             assert prod_config.sasl_password == 'prod-password'
-            assert prod_config.readonly is True
+            assert prod_config.viewonly is True
     
     def test_partial_cluster_configuration(self):
         """Test loading when only some clusters are configured."""
@@ -188,12 +188,12 @@ class TestMultiClusterOperations:
             'KAFKA_CLUSTER_NAME_1': 'cluster1',
             'KAFKA_BOOTSTRAP_SERVERS_1': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL_1': 'PLAINTEXT',
-            'READONLY_1': 'false',
+            'VIEWONLY_1': 'false',
             
             'KAFKA_CLUSTER_NAME_2': 'cluster2',
             'KAFKA_BOOTSTRAP_SERVERS_2': 'localhost:9093',
             'KAFKA_SECURITY_PROTOCOL_2': 'PLAINTEXT',
-            'READONLY_2': 'false',
+            'VIEWONLY_2': 'false',
         }, clear=True)
         self.env_patch.start()
         
@@ -275,30 +275,30 @@ class TestMultiClusterOperations:
         if cluster_id_1 and cluster_id_2:
             assert cluster_id_1 != cluster_id_2
     
-    def test_readonly_mode_per_cluster(self):
-        """Test that readonly mode can be set per cluster."""
-        # Check readonly status for each cluster
-        cluster1_readonly = self.manager.is_readonly('cluster1')
-        cluster2_readonly = self.manager.is_readonly('cluster2')
+    def test_viewonly_mode_per_cluster(self):
+        """Test that viewonly mode can be set per cluster."""
+        # Check viewonly status for each cluster
+        cluster1_viewonly = self.manager.is_viewonly('cluster1')
+        cluster2_viewonly = self.manager.is_viewonly('cluster2')
         
         # Based on our configuration, both should be writable
-        assert cluster1_readonly is False
-        assert cluster2_readonly is False
+        assert cluster1_viewonly is False
+        assert cluster2_viewonly is False
         
-        # Test configuration with mixed readonly settings
+        # Test configuration with mixed viewonly settings
         with patch.dict(os.environ, {
             'KAFKA_CLUSTER_NAME_1': 'dev',
             'KAFKA_BOOTSTRAP_SERVERS_1': 'localhost:9092',
-            'READONLY_1': 'false',
+            'VIEWONLY_1': 'false',
             
             'KAFKA_CLUSTER_NAME_2': 'prod',
             'KAFKA_BOOTSTRAP_SERVERS_2': 'localhost:9093',
-            'READONLY_2': 'true',  # Production is readonly
+            'VIEWONLY_2': 'true',  # Production is viewonly
         }, clear=True):
             mixed_manager = load_cluster_configurations()
             
-            assert mixed_manager.is_readonly('dev') is False
-            assert mixed_manager.is_readonly('prod') is True
+            assert mixed_manager.is_viewonly('dev') is False
+            assert mixed_manager.is_viewonly('prod') is True
 
 class TestMultiClusterErrorHandling:
     """Test error handling in multi-cluster scenarios."""

--- a/tests/test_topic_operations.py
+++ b/tests/test_topic_operations.py
@@ -46,7 +46,7 @@ class TestTopicOperations:
         self.env_patch = patch.dict(os.environ, {
             'KAFKA_BOOTSTRAP_SERVERS': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL': 'PLAINTEXT',
-            'READONLY': 'false'
+            'VIEWONLY': 'false'
         })
         self.env_patch.start()
         
@@ -277,7 +277,7 @@ class TestTopicValidation:
         self.env_patch = patch.dict(os.environ, {
             'KAFKA_BOOTSTRAP_SERVERS': 'localhost:9092',
             'KAFKA_SECURITY_PROTOCOL': 'PLAINTEXT',
-            'READONLY': 'false'
+            'VIEWONLY': 'false'
         })
         self.env_patch.start()
         self.manager = load_cluster_configurations()


### PR DESCRIPTION
- Rename 'readonly' to 'viewonly' in the main server code and related classes.
- Update environment variables and configuration files to reflect the change from READONLY to VIEWONLY.
- Modify documentation and README files to describe the new viewonly mode.
- Adjust tests to ensure compatibility with the updated viewonly functionality.
- Ensure all instances of readonly checks are replaced with viewonly checks in the codebase.