### PR TITLE
Add Kafka cluster management and resource modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY kafka_brokers_unified_mcp.py .
-COPY config-examples/ ./config-examples/
-
+COPY kafka_cluster_manager.py .
+COPY kafka_mcp_resources.py .
+COPY kafka_mcp_tools.py .
+    
 # Create non-root user
 RUN groupadd -r kafkamcp && useradd -r -g kafkamcp kafkamcp
 RUN chown -R kafkamcp:kafkamcp /app

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ This server uses the official MCP Python SDK and communicates via JSON-RPC over 
 ## ✨ Key Features
 
 - **Claude Desktop Compatible**: Direct integration with Claude Desktop via MCP protocol
-- **MCP Tools**: 15+ tools for topic operations, consumer group management, and cluster monitoring
-- **MCP Resources**: Real-time cluster status and configuration information
+- **MCP Tools**: 14 tools for topic operations, consumer group management, and cluster monitoring
+- **MCP Resources**: Real-time cluster status, configuration, and cluster-specific resources
 - **JSON-RPC Protocol**: Standard MCP communication over stdio
 - **Multi-Cluster Support**: Connect to up to 8 Kafka clusters simultaneously
 - **Per-Cluster VIEWONLY Mode**: Individual viewonly protection per cluster for production safety
 - **Cross-Cluster Operations**: Compare topics and consumer groups between clusters
+- **Health Monitoring**: Comprehensive cluster health checks and partition analysis
+- **Load Balancing Analysis**: Broker partition distribution and leader analysis
 - **Authentication Support**: SASL/SSL authentication for secure Kafka connections
 - **confluent-kafka-python**: High-performance Kafka client library
 
@@ -47,21 +49,33 @@ Restart Claude Desktop and start asking about your Kafka clusters!
 ## 📋 Core MCP Tools
 
 ### Topic Management
-- `list_topics` - List all topics with metadata
+- `list_topics(cluster?)` - List all topics with metadata (supports optional cluster parameter)
 - `describe_topic` - Get detailed topic configuration and partition info
-- `create_topic` - Create new topics (if not viewonly)
-- `delete_topic` - Delete topics (if not viewonly)
+- `get_topic_partition_details` - Get detailed partition info for a topic
 
 ### Consumer Group Management
-- `list_consumer_groups` - List all consumer groups
+- `list_consumer_groups(cluster?)` - List all consumer groups (supports optional cluster parameter)
 - `describe_consumer_group` - Get detailed consumer group info and offsets
-- `get_consumer_group_offsets` - Show current offsets and lag
 
 ### Broker Operations
-- `list_brokers` - List all brokers in cluster
-- `describe_broker` - Get broker details and configurations
+- `list_brokers(cluster?)` - List all brokers in cluster (supports optional cluster parameter)
+- `get_broker_partition_count` - Get partition distribution per broker
 - `get_cluster_metadata` - Show cluster-wide information
 - `list_clusters` - Show all configured clusters
+
+### Partition Operations
+- `get_partitions(cluster?, topic?)` - Get partitions with optional cluster and topic filtering
+- `get_partition_leaders` - Get partition leader distribution
+- `find_under_replicated_partitions` - Find unhealthy partitions
+
+### Health & Monitoring
+- `get_cluster_health` - Get comprehensive cluster health information
+- `compare_cluster_topics` - Compare topics between clusters
+
+### MCP Resources
+- Global resources: `kafka://brokers`, `kafka://topics`, `kafka://consumer-groups`, `kafka://partitions`
+- Cluster-specific resources: `kafka://brokers/{name}`, `kafka://topics/{name}`, etc.
+- Cluster status: `kafka://cluster-status`, `kafka://cluster-info`
 
 ## 🔧 Configuration
 
@@ -118,12 +132,37 @@ cd tests
 
 Once connected to Claude Desktop:
 
+### Basic Operations
 - "List all topics in my Kafka cluster"
 - "Show me details about the user-events topic"
 - "What consumer groups are active?"
 - "Describe the consumer group 'analytics-service'"
 - "Show me all brokers in the production cluster"
+
+### Cluster-Specific Operations (NEW)
+- "Get brokers for the production cluster using get_brokers with cluster parameter"
+- "Show me topics in the development cluster only"
+- "Get consumer groups for production cluster using cluster parameter"
+- "Get partitions for user-events topic in production cluster"
+- "Show me partitions for the production cluster"
+
+### Health & Monitoring (NEW)
+- "Check the health of my production cluster"
+- "Find any under-replicated partitions in development"
+- "Show me partition leader distribution for production"
+- "Get broker partition counts to check load balancing"
+- "Analyze topic partition details for high-volume-topic"
+
+### Cross-Cluster Operations
 - "Compare topics between development and production clusters"
+- "Show me brokers across all my clusters"
+- "Which consumer groups exist in both environments?"
+- "Compare partition counts between dev and prod for user-events topic"
+
+### Resource-Based Operations
+- "Access the kafka://cluster-health/production resource"
+- "Get data from kafka://brokers/development"
+- "Show me the kafka://topics/production resource"
 
 ## 🔒 VIEWONLY Mode
 
@@ -153,8 +192,21 @@ When `VIEWONLY=true` is set, the MCP server blocks all modification operations:
 - Cluster health monitoring
 
 ### Real-time Resources
-- `kafka://cluster-status` - Live cluster status
-- `kafka://cluster-info` - Detailed configuration
+
+#### Global Resources
+- `kafka://cluster-status` - Live cluster status across all clusters
+- `kafka://cluster-info` - Detailed configuration for all clusters
+- `kafka://brokers` - All brokers across clusters
+- `kafka://topics` - All topics across clusters
+- `kafka://consumer-groups` - All consumer groups across clusters
+- `kafka://partitions` - All partitions across clusters
+
+#### Cluster-Specific Resources (NEW)
+- `kafka://brokers/{name}` - Brokers for a specific cluster
+- `kafka://topics/{name}` - Topics for a specific cluster
+- `kafka://consumer-groups/{name}` - Consumer groups for a specific cluster
+- `kafka://partitions/{name}` - Partitions for a specific cluster
+- `kafka://cluster-health/{name}` - Health metrics for a specific cluster
 
 ## 📊 Monitoring
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -55,6 +55,230 @@ Provides detailed cluster configuration information.
 }
 ```
 
+### kafka://brokers
+
+Provides real-time broker information across all clusters.
+
+**Returns:** JSON string with broker details for all clusters
+
+```json
+{
+  "brokers": {
+    "default": [
+      {
+        "broker_id": 1,
+        "host": "localhost",
+        "port": 9092,
+        "rack": null,
+        "cluster": "default"
+      }
+    ]
+  },
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://topics
+
+Provides real-time topic information across all clusters.
+
+**Returns:** JSON string with topic details for all clusters
+
+```json
+{
+  "topics": {
+    "default": [
+      {
+        "name": "user-events",
+        "partitions": 6,
+        "replication_factor": 3,
+        "internal": false,
+        "cluster": "default"
+      }
+    ]
+  },
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://consumer-groups
+
+Provides real-time consumer group information across all clusters.
+
+**Returns:** JSON string with consumer group details for all clusters
+
+```json
+{
+  "consumer_groups": {
+    "default": [
+      {
+        "group_id": "analytics-service",
+        "is_simple_consumer_group": false,
+        "state": "STABLE",
+        "cluster": "default"
+      }
+    ]
+  },
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://partitions
+
+Provides real-time partition information across all clusters.
+
+**Returns:** JSON string with partition details for all clusters
+
+```json
+{
+  "partitions": {
+    "default": [
+      {
+        "topic": "user-events",
+        "partition_id": 0,
+        "leader": 1,
+        "replicas": [1, 2, 3],
+        "in_sync_replicas": [1, 2, 3],
+        "error": null,
+        "cluster": "default"
+      }
+    ]
+  },
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://brokers/{name}
+
+Provides real-time broker information for a specific cluster.
+
+**Parameters:**
+- `name`: Cluster name
+
+**Returns:** JSON string with broker details for the specified cluster
+
+```json
+{
+  "cluster": "production",
+  "brokers": [
+    {
+      "broker_id": 1,
+      "host": "prod-kafka-1",
+      "port": 9092,
+      "rack": "rack-1",
+      "cluster": "production"
+    }
+  ],
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://topics/{name}
+
+Provides real-time topic information for a specific cluster.
+
+**Parameters:**
+- `name`: Cluster name
+
+**Returns:** JSON string with topic details for the specified cluster
+
+```json
+{
+  "cluster": "production",
+  "topics": [
+    {
+      "name": "user-events",
+      "partitions": 6,
+      "replication_factor": 3,
+      "internal": false,
+      "cluster": "production"
+    }
+  ],
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://consumer-groups/{name}
+
+Provides real-time consumer group information for a specific cluster.
+
+**Parameters:**
+- `name`: Cluster name
+
+**Returns:** JSON string with consumer group details for the specified cluster
+
+```json
+{
+  "cluster": "production",
+  "consumer_groups": [
+    {
+      "group_id": "analytics-service",
+      "is_simple_consumer_group": false,
+      "state": "STABLE",
+      "cluster": "production"
+    }
+  ],
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://partitions/{name}
+
+Provides real-time partition information for a specific cluster.
+
+**Parameters:**
+- `name`: Cluster name
+
+**Returns:** JSON string with partition details for the specified cluster
+
+```json
+{
+  "cluster": "production",
+  "partitions": [
+    {
+      "topic": "user-events",
+      "partition_id": 0,
+      "leader": 1,
+      "replicas": [1, 2, 3],
+      "in_sync_replicas": [1, 2, 3],
+      "error": null,
+      "cluster": "production"
+    }
+  ],
+  "timestamp": 1704067200.0
+}
+```
+
+### kafka://cluster-health/{name}
+
+Provides comprehensive health information for a specific cluster.
+
+**Parameters:**
+- `name`: Cluster name
+
+**Returns:** JSON string with health metrics for the specified cluster
+
+```json
+{
+  "cluster": "production",
+  "health_status": "healthy",
+  "cluster_info": {
+    "cluster_id": "kafka-cluster-prod",
+    "controller_id": 1,
+    "bootstrap_servers": "prod-kafka:9092",
+    "viewonly": true
+  },
+  "metrics": {
+    "broker_count": 3,
+    "topic_count": 15,
+    "partition_count": 120,
+    "unhealthy_partitions": 0,
+    "health_percentage": 100.0
+  },
+  "timestamp": 1704067200.0
+}
+```
+
 ## MCP Tools
 
 ### list_clusters()
@@ -293,6 +517,246 @@ Provides comprehensive cluster metadata and statistics.
     "authentication_enabled": true
   }
 }
+```
+
+
+
+
+
+
+
+### get_partitions(cluster: Optional[str] = None, topic: Optional[str] = None)
+
+Get partitions from kafka://partitions resource or cluster-specific resource.
+
+**Parameters:**
+- `cluster` (optional): Cluster name. If specified, uses cluster-specific resource. If not specified, returns partitions from all clusters.
+- `topic` (optional): Topic name. If specified, returns only partitions for that topic.
+
+**Returns:** `List[Dict[str, Any]]`
+
+**Example:**
+```python
+# All clusters, all topics
+[
+  {
+    "topic": "user-events",
+    "partition_id": 0,
+    "leader": 1,
+    "replicas": [1, 2, 3],
+    "in_sync_replicas": [1, 2, 3],
+    "error": null,
+    "cluster": "default"
+  },
+  {
+    "topic": "user-events",
+    "partition_id": 1,
+    "leader": 2,
+    "replicas": [2, 3, 1],
+    "in_sync_replicas": [2, 3, 1],
+    "error": null,
+    "cluster": "production"
+  }
+]
+
+# Specific cluster and topic: get_partitions(cluster="production", topic="user-events")
+[
+  {
+    "topic": "user-events",
+    "partition_id": 1,
+    "leader": 2,
+    "replicas": [2, 3, 1],
+    "in_sync_replicas": [2, 3, 1],
+    "error": null,
+    "cluster": "production"
+  }
+]
+```
+
+### get_cluster_health(cluster: str)
+
+Get comprehensive health information for a specific cluster.
+
+**Parameters:**
+- `cluster`: Name of the cluster
+
+**Returns:** `Dict[str, Any]`
+
+**Example:**
+```python
+{
+  "cluster": "production",
+  "health_status": "healthy",
+  "cluster_info": {
+    "cluster_id": "kafka-cluster-prod",
+    "controller_id": 1,
+    "bootstrap_servers": "prod-kafka:9092",
+    "viewonly": true
+  },
+  "metrics": {
+    "broker_count": 3,
+    "topic_count": 15,
+    "partition_count": 120,
+    "unhealthy_partitions": 0,
+    "health_percentage": 100.0
+  }
+}
+```
+
+### compare_cluster_topics(source_cluster: str, target_cluster: str)
+
+Compare topics between two clusters.
+
+**Parameters:**
+- `source_cluster`: Name of the source cluster
+- `target_cluster`: Name of the target cluster
+
+**Returns:** `Dict[str, Any]`
+
+**Example:**
+```python
+{
+  "source_cluster": "development",
+  "target_cluster": "production",
+  "summary": {
+    "total_source_topics": 5,
+    "total_target_topics": 15,
+    "common_topics": 5,
+    "only_in_source": 0,
+    "only_in_target": 10,
+    "topics_with_differences": 2
+  },
+  "only_in_source": [],
+  "only_in_target": ["prod-only-topic"],
+  "topic_differences": [
+    {
+      "topic": "user-events",
+      "differences": {
+        "partitions": {"source": 3, "target": 6}
+      }
+    }
+  ]
+}
+```
+
+### get_partition_leaders(cluster_name: str)
+
+Get partition leader distribution across brokers for a cluster.
+
+**Parameters:**
+- `cluster_name`: Name of the cluster
+
+**Returns:** `Dict[str, Any]`
+
+**Example:**
+```python
+{
+  "cluster": "production",
+  "total_partitions": 120,
+  "total_brokers": 3,
+  "leader_distribution": [
+    {
+      "broker_id": 1,
+      "host": "kafka-1",
+      "port": 9092,
+      "partition_count": 40,
+      "topics": {"user-events": 6, "orders": 3}
+    }
+  ],
+  "balance_ratio": 0.95
+}
+```
+
+### get_topic_partition_details(cluster_name: str, topic_name: str)
+
+Get detailed partition information for a specific topic.
+
+**Parameters:**
+- `cluster_name`: Name of the cluster
+- `topic_name`: Name of the topic
+
+**Returns:** `Dict[str, Any]`
+
+**Example:**
+```python
+{
+  "cluster": "production",
+  "topic": "user-events",
+  "partition_count": 6,
+  "replication_factor": 3,
+  "health": {
+    "healthy_partitions": 6,
+    "unhealthy_partitions": 0,
+    "health_percentage": 100.0
+  },
+  "partitions": [
+    {
+      "partition_id": 0,
+      "leader": {
+        "broker_id": 1,
+        "host": "kafka-1",
+        "port": 9092
+      },
+      "replicas": [
+        {
+          "broker_id": 1,
+          "host": "kafka-1",
+          "port": 9092,
+          "in_sync": true
+        }
+      ],
+      "is_healthy": true
+    }
+  ]
+}
+```
+
+### find_under_replicated_partitions(cluster_name: str)
+
+Find partitions that are under-replicated (fewer ISRs than replicas).
+
+**Parameters:**
+- `cluster_name`: Name of the cluster
+
+**Returns:** `List[Dict[str, Any]]`
+
+**Example:**
+```python
+[
+  {
+    "topic": "user-events",
+    "partition_id": 2,
+    "leader": 1,
+    "replicas": [1, 2, 3],
+    "in_sync_replicas": [1, 3],
+    "missing_replicas": 1,
+    "replication_factor": 3,
+    "cluster": "production"
+  }
+]
+```
+
+### get_broker_partition_count(cluster_name: str)
+
+Get partition count per broker for load balancing analysis.
+
+**Parameters:**
+- `cluster_name`: Name of the cluster
+
+**Returns:** `List[Dict[str, Any]]`
+
+**Example:**
+```python
+[
+  {
+    "broker_id": 1,
+    "host": "kafka-1",
+    "port": 9092,
+    "leader_count": 40,
+    "replica_count": 120,
+    "topic_count": 15
+  }
+]
 ```
 
 ## Error Handling

--- a/kafka_brokers_unified_mcp.py
+++ b/kafka_brokers_unified_mcp.py
@@ -5,557 +5,158 @@ A comprehensive MCP server for Kafka broker operations using confluent-kafka-pyt
 Supports single and multi-cluster configurations with viewonly mode protection.
 """
 
-import asyncio
-import json
 import logging
-import os
 import sys
-from typing import Any, Dict, List, Optional, Union
-from dataclasses import dataclass
-from concurrent.futures import ThreadPoolExecutor
-import time
 
-from confluent_kafka import Consumer, Producer, TopicPartition
-from confluent_kafka.admin import AdminClient, ConfigResource, NewTopic
 from mcp.server.fastmcp import FastMCP
-from mcp.server.models import InitializationOptions
-from mcp.types import Resource, Tool, TextContent, ImageContent, EmbeddedResource
+
+# Import modules
+from kafka_cluster_manager import load_cluster_configurations
+import kafka_mcp_resources as resources
+import kafka_mcp_tools as tools
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-
-@dataclass
-class KafkaClusterConfig:
-    """Configuration for a Kafka cluster connection."""
-
-    name: str
-    bootstrap_servers: str
-    security_protocol: str = "PLAINTEXT"
-    sasl_mechanism: Optional[str] = None
-    sasl_username: Optional[str] = None
-    sasl_password: Optional[str] = None
-    ssl_ca_location: Optional[str] = None
-    ssl_certificate_location: Optional[str] = None
-    ssl_key_location: Optional[str] = None
-    viewonly: bool = False
-
-
-class KafkaClusterManager:
-    """Manages Kafka cluster connections and operations."""
-
-    def __init__(self):
-        self.clusters: Dict[str, KafkaClusterConfig] = {}
-        self.admin_clients: Dict[str, AdminClient] = {}
-        self.executor = ThreadPoolExecutor(max_workers=10)
-
-    def add_cluster(self, config: KafkaClusterConfig):
-        """Add a cluster configuration."""
-        self.clusters[config.name] = config
-        self._create_admin_client(config)
-
-    def _create_admin_client(self, config: KafkaClusterConfig):
-        """Create an AdminClient for the cluster."""
-        kafka_config = {
-            "bootstrap.servers": config.bootstrap_servers,
-            "security.protocol": config.security_protocol,
-        }
-
-        if config.sasl_mechanism:
-            kafka_config["sasl.mechanism"] = config.sasl_mechanism
-        if config.sasl_username:
-            kafka_config["sasl.username"] = config.sasl_username
-        if config.sasl_password:
-            kafka_config["sasl.password"] = config.sasl_password
-        if config.ssl_ca_location:
-            kafka_config["ssl.ca.location"] = config.ssl_ca_location
-        if config.ssl_certificate_location:
-            kafka_config["ssl.certificate.location"] = config.ssl_certificate_location
-        if config.ssl_key_location:
-            kafka_config["ssl.key.location"] = config.ssl_key_location
-
-        self.admin_clients[config.name] = AdminClient(kafka_config)
-
-    def get_admin_client(self, cluster_name: Optional[str] = None) -> AdminClient:
-        """Get AdminClient for specified cluster or default."""
-        if cluster_name is None:
-            if len(self.admin_clients) == 1:
-                return list(self.admin_clients.values())[0]
-            elif "default" in self.admin_clients:
-                return self.admin_clients["default"]
-            else:
-                raise ValueError("Multiple clusters available, please specify cluster_name")
-
-        if cluster_name not in self.admin_clients:
-            raise ValueError(f"Cluster '{cluster_name}' not found")
-
-        return self.admin_clients[cluster_name]
-
-    def get_cluster_config(self, cluster_name: Optional[str] = None) -> KafkaClusterConfig:
-        """Get cluster configuration."""
-        if cluster_name is None:
-            if len(self.clusters) == 1:
-                return list(self.clusters.values())[0]
-            elif "default" in self.clusters:
-                return self.clusters["default"]
-            else:
-                raise ValueError("Multiple clusters available, please specify cluster_name")
-
-        if cluster_name not in self.clusters:
-            raise ValueError(f"Cluster '{cluster_name}' not found")
-
-        return self.clusters[cluster_name]
-
-    def is_viewonly(self, cluster_name: Optional[str] = None) -> bool:
-        """Check if cluster is in viewonly mode."""
-        config = self.get_cluster_config(cluster_name)
-        return config.viewonly
-
-
-def load_cluster_configurations() -> KafkaClusterManager:
-    """Load cluster configurations from environment variables."""
-    manager = KafkaClusterManager()
-
-    # Check for single cluster mode first
-    bootstrap_servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS")
-    if bootstrap_servers:
-        config = KafkaClusterConfig(
-            name="default",
-            bootstrap_servers=bootstrap_servers,
-            security_protocol=os.getenv("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT"),
-            sasl_mechanism=os.getenv("KAFKA_SASL_MECHANISM"),
-            sasl_username=os.getenv("KAFKA_SASL_USERNAME"),
-            sasl_password=os.getenv("KAFKA_SASL_PASSWORD"),
-            ssl_ca_location=os.getenv("KAFKA_SSL_CA_LOCATION"),
-            ssl_certificate_location=os.getenv("KAFKA_SSL_CERTIFICATE_LOCATION"),
-            ssl_key_location=os.getenv("KAFKA_SSL_KEY_LOCATION"),
-            viewonly=os.getenv("VIEWONLY", "false").lower() == "true",
-        )
-        manager.add_cluster(config)
-        logger.info(f"Loaded single cluster configuration: {bootstrap_servers}")
-        return manager
-
-    # Check for multi-cluster mode
-    for i in range(1, 9):  # Support up to 8 clusters
-        name = os.getenv(f"KAFKA_CLUSTER_NAME_{i}")
-        servers = os.getenv(f"KAFKA_BOOTSTRAP_SERVERS_{i}")
-
-        if name and servers:
-            config = KafkaClusterConfig(
-                name=name,
-                bootstrap_servers=servers,
-                security_protocol=os.getenv(f"KAFKA_SECURITY_PROTOCOL_{i}", "PLAINTEXT"),
-                sasl_mechanism=os.getenv(f"KAFKA_SASL_MECHANISM_{i}"),
-                sasl_username=os.getenv(f"KAFKA_SASL_USERNAME_{i}"),
-                sasl_password=os.getenv(f"KAFKA_SASL_PASSWORD_{i}"),
-                ssl_ca_location=os.getenv(f"KAFKA_SSL_CA_LOCATION_{i}"),
-                ssl_certificate_location=os.getenv(f"KAFKA_SSL_CERTIFICATE_LOCATION_{i}"),
-                ssl_key_location=os.getenv(f"KAFKA_SSL_KEY_LOCATION_{i}"),
-                viewonly=os.getenv(f"VIEWONLY_{i}", "false").lower() == "true",
-            )
-            manager.add_cluster(config)
-            logger.info(f"Loaded cluster configuration: {name} -> {servers}")
-
-    if not manager.clusters:
-        raise ValueError(
-            "No cluster configurations found. Set KAFKA_BOOTSTRAP_SERVERS or KAFKA_CLUSTER_NAME_X/KAFKA_BOOTSTRAP_SERVERS_X"
-        )
-
-    return manager
-
-
 # Initialize the cluster manager
 cluster_manager = load_cluster_configurations()
+
+# Set cluster manager for modules
+resources.set_cluster_manager(cluster_manager)
+tools.set_cluster_manager(cluster_manager)
 
 # Create the MCP server
 mcp = FastMCP("Kafka Brokers MCP Server")
 
 
+# Register MCP Resources
 @mcp.resource("kafka://cluster-status")
 async def get_cluster_status() -> str:
-    """Get real-time cluster status information."""
-    status = {"clusters": {}, "timestamp": time.time()}
-
-    for name, config in cluster_manager.clusters.items():
-        try:
-            admin_client = cluster_manager.get_admin_client(name)
-            metadata = admin_client.list_topics(timeout=10)
-
-            status["clusters"][name] = {
-                "name": name,
-                "bootstrap_servers": config.bootstrap_servers,
-                "viewonly": config.viewonly,
-                "topics_count": len(metadata.topics),
-                "brokers_count": len(metadata.brokers),
-                "status": "healthy",
-            }
-        except Exception as e:
-            status["clusters"][name] = {
-                "name": name,
-                "bootstrap_servers": config.bootstrap_servers,
-                "viewonly": config.viewonly,
-                "status": "error",
-                "error": str(e),
-            }
-
-    return json.dumps(status, indent=2)
+    return await resources.get_cluster_status()
 
 
 @mcp.resource("kafka://cluster-info")
 async def get_cluster_info() -> str:
-    """Get detailed cluster configuration information."""
-    info = {
-        "server_version": "1.0.0",
-        "clusters": {},
-        "configuration": {
-            "viewonly_protection": any(c.viewonly for c in cluster_manager.clusters.values()),
-            "multi_cluster_mode": len(cluster_manager.clusters) > 1,
-            "total_clusters": len(cluster_manager.clusters),
-        },
-    }
-
-    for name, config in cluster_manager.clusters.items():
-        info["clusters"][name] = {
-            "name": config.name,
-            "bootstrap_servers": config.bootstrap_servers,
-            "security_protocol": config.security_protocol,
-            "viewonly": config.viewonly,
-            "authentication": {
-                "sasl_mechanism": config.sasl_mechanism,
-                "has_credentials": bool(config.sasl_username),
-            },
-        }
-
-    return json.dumps(info, indent=2)
+    return await resources.get_cluster_info()
 
 
-# MCP Tools Implementation
+@mcp.resource("kafka://brokers")
+async def get_brokers_resource() -> str:
+    return await resources.get_brokers_resource()
+
+
+@mcp.resource("kafka://topics")
+async def get_topics_resource() -> str:
+    return await resources.get_topics_resource()
+
+
+@mcp.resource("kafka://consumer-groups")
+async def get_consumer_groups_resource() -> str:
+    return await resources.get_consumer_groups_resource()
+
+
+@mcp.resource("kafka://partitions")
+async def get_partitions_resource() -> str:
+    return await resources.get_partitions_resource()
+
+
+@mcp.resource("kafka://brokers/{name}")
+async def get_cluster_brokers_resource(name: str) -> str:
+    return await resources.get_cluster_brokers_resource(name)
+
+
+@mcp.resource("kafka://topics/{name}")
+async def get_cluster_topics_resource(name: str) -> str:
+    return await resources.get_cluster_topics_resource(name)
+
+
+@mcp.resource("kafka://consumer-groups/{name}")
+async def get_cluster_consumer_groups_resource(name: str) -> str:
+    return await resources.get_cluster_consumer_groups_resource(name)
+
+
+@mcp.resource("kafka://partitions/{name}")
+async def get_cluster_partitions_resource(name: str) -> str:
+    return await resources.get_cluster_partitions_resource(name)
+
+
+@mcp.resource("kafka://cluster-health/{name}")
+async def get_cluster_health_resource(name: str) -> str:
+    return await resources.get_cluster_health_resource(name)
+
+
+# Register MCP Tools
+@mcp.tool()
+async def list_clusters():
+    return await tools.list_clusters()
 
 
 @mcp.tool()
-async def list_clusters() -> List[Dict[str, Any]]:
-    """List all configured Kafka clusters."""
-    clusters = []
-    for name, config in cluster_manager.clusters.items():
-        try:
-            admin_client = cluster_manager.get_admin_client(name)
-            metadata = admin_client.list_topics(timeout=10)
-
-            clusters.append(
-                {
-                    "name": name,
-                    "bootstrap_servers": config.bootstrap_servers,
-                    "security_protocol": config.security_protocol,
-                    "viewonly": config.viewonly,
-                    "topics_count": len(metadata.topics),
-                    "brokers_count": len(metadata.brokers),
-                    "status": "healthy",
-                }
-            )
-        except Exception as e:
-            clusters.append(
-                {
-                    "name": name,
-                    "bootstrap_servers": config.bootstrap_servers,
-                    "viewonly": config.viewonly,
-                    "status": "error",
-                    "error": str(e),
-                }
-            )
-
-    return clusters
+async def list_topics(cluster=None):
+    return await tools.list_topics(cluster)
 
 
 @mcp.tool()
-async def list_topics(cluster: Optional[str] = None) -> List[Dict[str, Any]]:
-    """List all topics in the specified cluster."""
-    try:
-        admin_client = cluster_manager.get_admin_client(cluster)
-
-        # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
-        metadata = await loop.run_in_executor(cluster_manager.executor, lambda: admin_client.list_topics(timeout=10))
-
-        topics = []
-        for topic_name, topic_metadata in metadata.topics.items():
-            if not topic_name.startswith("__"):  # Filter internal topics
-                topics.append(
-                    {
-                        "name": topic_name,
-                        "partitions": len(topic_metadata.partitions),
-                        "replication_factor": len(topic_metadata.partitions[0].replicas) if topic_metadata.partitions else 0,
-                        "internal": False,
-                    }
-                )
-
-        return sorted(topics, key=lambda x: x["name"])
-
-    except Exception as e:
-        logger.error(f"Error listing topics: {e}")
-        raise
+async def describe_topic(topic_name: str, cluster=None):
+    return await tools.describe_topic(topic_name, cluster)
 
 
 @mcp.tool()
-async def describe_topic(topic_name: str, cluster: Optional[str] = None) -> Dict[str, Any]:
-    """Get detailed information about a specific topic."""
-    try:
-        admin_client = cluster_manager.get_admin_client(cluster)
-
-        # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
-        metadata = await loop.run_in_executor(
-            cluster_manager.executor, lambda: admin_client.list_topics(topic=topic_name, timeout=10)
-        )
-
-        if topic_name not in metadata.topics:
-            raise ValueError(f"Topic '{topic_name}' not found")
-
-        topic_metadata = metadata.topics[topic_name]
-
-        # Get topic configurations
-        config_resource = ConfigResource(ConfigResource.Type.TOPIC, topic_name)
-        configs = await loop.run_in_executor(
-            cluster_manager.executor,
-            lambda: admin_client.describe_configs([config_resource], request_timeout=10),
-        )
-
-        topic_configs = {}
-        if config_resource in configs:
-            config_result = configs[config_resource].result()
-            topic_configs = {k: v.value for k, v in config_result.items()}
-
-        # Build partition details
-        partitions = []
-        for partition_id, partition_metadata in topic_metadata.partitions.items():
-            partitions.append(
-                {
-                    "partition_id": partition_id,
-                    "leader": partition_metadata.leader,
-                    "replicas": partition_metadata.replicas,
-                    "in_sync_replicas": partition_metadata.isrs,
-                    "error": str(partition_metadata.error) if partition_metadata.error else None,
-                }
-            )
-
-        return {
-            "name": topic_name,
-            "partitions": sorted(partitions, key=lambda x: x["partition_id"]),
-            "partition_count": len(partitions),
-            "replication_factor": len(partitions[0]["replicas"]) if partitions else 0,
-            "configurations": topic_configs,
-            "internal": topic_metadata.error is not None,
-        }
-
-    except Exception as e:
-        logger.error(f"Error describing topic {topic_name}: {e}")
-        raise
+async def list_consumer_groups(cluster=None):
+    return await tools.list_consumer_groups(cluster)
 
 
 @mcp.tool()
-async def list_consumer_groups(cluster: Optional[str] = None) -> List[Dict[str, Any]]:
-    """List all consumer groups in the specified cluster."""
-    try:
-        admin_client = cluster_manager.get_admin_client(cluster)
-
-        # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(cluster_manager.executor, lambda: admin_client.list_consumer_groups(timeout=10))
-
-        groups = []
-        for group in result.result():
-            groups.append(
-                {
-                    "group_id": group.group_id,
-                    "is_simple_consumer_group": group.is_simple_consumer_group,
-                    "state": group.state.name if hasattr(group, "state") else "UNKNOWN",
-                }
-            )
-
-        return sorted(groups, key=lambda x: x["group_id"])
-
-    except Exception as e:
-        logger.error(f"Error listing consumer groups: {e}")
-        raise
+async def describe_consumer_group(group_id: str, cluster=None):
+    return await tools.describe_consumer_group(group_id, cluster)
 
 
 @mcp.tool()
-async def describe_consumer_group(group_id: str, cluster: Optional[str] = None) -> Dict[str, Any]:
-    """Get detailed information about a specific consumer group."""
-    try:
-        admin_client = cluster_manager.get_admin_client(cluster)
-
-        # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
-
-        # Describe the consumer group
-        result = await loop.run_in_executor(
-            cluster_manager.executor, lambda: admin_client.describe_consumer_groups([group_id], timeout=10)
-        )
-
-        if group_id not in result:
-            raise ValueError(f"Consumer group '{group_id}' not found")
-
-        group_description = result[group_id].result()
-
-        # Get consumer group offsets
-        def get_offsets():
-            # Create a temporary consumer to get committed offsets
-            consumer_config = {
-                "bootstrap.servers": cluster_manager.get_cluster_config(cluster).bootstrap_servers,
-                "group.id": group_id,
-                "auto.offset.reset": "earliest",
-            }
-
-            config = cluster_manager.get_cluster_config(cluster)
-            if config.security_protocol != "PLAINTEXT":
-                consumer_config["security.protocol"] = config.security_protocol
-                if config.sasl_mechanism:
-                    consumer_config["sasl.mechanism"] = config.sasl_mechanism
-                if config.sasl_username:
-                    consumer_config["sasl.username"] = config.sasl_username
-                if config.sasl_password:
-                    consumer_config["sasl.password"] = config.sasl_password
-
-            consumer = Consumer(consumer_config)
-            try:
-                # Get list of topics this group is consuming from
-                metadata = admin_client.list_topics(timeout=10)
-                all_partitions = []
-
-                for topic_name in metadata.topics:
-                    topic_partitions = consumer.list_consumer_group_offsets([group_id], [TopicPartition(topic_name)])
-                    if topic_partitions:
-                        all_partitions.extend(topic_partitions)
-
-                committed_offsets = consumer.committed(all_partitions, timeout=10)
-                return committed_offsets
-            finally:
-                consumer.close()
-
-        offsets = await loop.run_in_executor(cluster_manager.executor, get_offsets)
-
-        # Format member information
-        members = []
-        for member in group_description.members:
-            members.append(
-                {
-                    "member_id": member.member_id,
-                    "client_id": member.client_id,
-                    "client_host": member.client_host,
-                    "assignments": (
-                        [{"topic": tp.topic, "partition": tp.partition} for tp in member.assignment.topic_partitions]
-                        if member.assignment
-                        else []
-                    ),
-                }
-            )
-
-        # Format offset information
-        offset_info = []
-        for tp in offsets:
-            if tp.offset >= 0:  # Valid offset
-                offset_info.append(
-                    {
-                        "topic": tp.topic,
-                        "partition": tp.partition,
-                        "current_offset": tp.offset,
-                        "metadata": tp.metadata,
-                    }
-                )
-
-        return {
-            "group_id": group_id,
-            "state": group_description.state.name,
-            "protocol_type": group_description.protocol_type,
-            "protocol": group_description.protocol,
-            "coordinator": {
-                "id": group_description.coordinator.id,
-                "host": group_description.coordinator.host,
-                "port": group_description.coordinator.port,
-            },
-            "members": members,
-            "member_count": len(members),
-            "offsets": offset_info,
-        }
-
-    except Exception as e:
-        logger.error(f"Error describing consumer group {group_id}: {e}")
-        raise
+async def list_brokers(cluster=None):
+    return await tools.list_brokers(cluster)
 
 
 @mcp.tool()
-async def list_brokers(cluster: Optional[str] = None) -> List[Dict[str, Any]]:
-    """List all brokers in the specified cluster."""
-    try:
-        admin_client = cluster_manager.get_admin_client(cluster)
-
-        # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
-        metadata = await loop.run_in_executor(cluster_manager.executor, lambda: admin_client.list_topics(timeout=10))
-
-        brokers = []
-        for broker_id, broker_metadata in metadata.brokers.items():
-            brokers.append(
-                {
-                    "broker_id": broker_id,
-                    "host": broker_metadata.host,
-                    "port": broker_metadata.port,
-                    "rack": getattr(broker_metadata, "rack", None),
-                }
-            )
-
-        return sorted(brokers, key=lambda x: x["broker_id"])
-
-    except Exception as e:
-        logger.error(f"Error listing brokers: {e}")
-        raise
+async def get_cluster_metadata(cluster=None):
+    return await tools.get_cluster_metadata(cluster)
 
 
 @mcp.tool()
-async def get_cluster_metadata(cluster: Optional[str] = None) -> Dict[str, Any]:
-    """Get comprehensive cluster metadata and information."""
-    try:
-        admin_client = cluster_manager.get_admin_client(cluster)
-        config = cluster_manager.get_cluster_config(cluster)
-
-        # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
-        metadata = await loop.run_in_executor(cluster_manager.executor, lambda: admin_client.list_topics(timeout=10))
-
-        # Count topics (excluding internal ones)
-        user_topics = [name for name in metadata.topics.keys() if not name.startswith("__")]
-        internal_topics = [name for name in metadata.topics.keys() if name.startswith("__")]
-
-        # Calculate total partitions
-        total_partitions = sum(len(topic.partitions) for topic in metadata.topics.values())
-
-        return {
-            "cluster_name": config.name,
-            "bootstrap_servers": config.bootstrap_servers,
-            "viewonly": config.viewonly,
-            "cluster_id": metadata.cluster_id,
-            "controller_id": metadata.controller_id,
-            "brokers": {"count": len(metadata.brokers), "ids": list(metadata.brokers.keys())},
-            "topics": {
-                "total": len(metadata.topics),
-                "user_topics": len(user_topics),
-                "internal_topics": len(internal_topics),
-                "total_partitions": total_partitions,
-            },
-            "security": {
-                "protocol": config.security_protocol,
-                "sasl_mechanism": config.sasl_mechanism,
-                "authentication_enabled": bool(config.sasl_username),
-            },
-        }
-
-    except Exception as e:
-        logger.error(f"Error getting cluster metadata: {e}")
-        raise
+async def get_partitions(cluster=None, topic=None):
+    return await tools.get_partitions(cluster, topic)
 
 
-# Main function
+@mcp.tool()
+async def get_cluster_health(cluster: str):
+    return await tools.get_cluster_health(cluster)
+
+
+@mcp.tool()
+async def compare_cluster_topics(source_cluster: str, target_cluster: str):
+    return await tools.compare_cluster_topics(source_cluster, target_cluster)
+
+
+@mcp.tool()
+async def get_partition_leaders(cluster_name: str):
+    return await tools.get_partition_leaders(cluster_name)
+
+
+@mcp.tool()
+async def get_topic_partition_details(cluster_name: str, topic_name: str):
+    return await tools.get_topic_partition_details(cluster_name, topic_name)
+
+
+@mcp.tool()
+async def find_under_replicated_partitions(cluster_name: str):
+    return await tools.find_under_replicated_partitions(cluster_name)
+
+
+@mcp.tool()
+async def get_broker_partition_count(cluster_name: str):
+    return await tools.get_broker_partition_count(cluster_name)
+
+
 def main():
     """Main entry point for the MCP server."""
     try:

--- a/kafka_cluster_manager.py
+++ b/kafka_cluster_manager.py
@@ -1,0 +1,154 @@
+"""
+Kafka Cluster Management Module
+Handles cluster configuration, connections, and AdminClient management.
+"""
+
+import logging
+import os
+from typing import Dict, Optional
+from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
+
+from confluent_kafka.admin import AdminClient
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KafkaClusterConfig:
+    """Configuration for a Kafka cluster connection."""
+
+    name: str
+    bootstrap_servers: str
+    security_protocol: str = "PLAINTEXT"
+    sasl_mechanism: Optional[str] = None
+    sasl_username: Optional[str] = None
+    sasl_password: Optional[str] = None
+    ssl_ca_location: Optional[str] = None
+    ssl_certificate_location: Optional[str] = None
+    ssl_key_location: Optional[str] = None
+    viewonly: bool = False
+
+
+class KafkaClusterManager:
+    """Manages Kafka cluster connections and operations."""
+
+    def __init__(self):
+        self.clusters: Dict[str, KafkaClusterConfig] = {}
+        self.admin_clients: Dict[str, AdminClient] = {}
+        self.executor = ThreadPoolExecutor(max_workers=10)
+
+    def add_cluster(self, config: KafkaClusterConfig):
+        """Add a cluster configuration."""
+        self.clusters[config.name] = config
+        self._create_admin_client(config)
+
+    def _create_admin_client(self, config: KafkaClusterConfig):
+        """Create an AdminClient for the cluster."""
+        kafka_config = {
+            "bootstrap.servers": config.bootstrap_servers,
+            "security.protocol": config.security_protocol,
+        }
+
+        if config.sasl_mechanism:
+            kafka_config["sasl.mechanism"] = config.sasl_mechanism
+        if config.sasl_username:
+            kafka_config["sasl.username"] = config.sasl_username
+        if config.sasl_password:
+            kafka_config["sasl.password"] = config.sasl_password
+        if config.ssl_ca_location:
+            kafka_config["ssl.ca.location"] = config.ssl_ca_location
+        if config.ssl_certificate_location:
+            kafka_config["ssl.certificate.location"] = config.ssl_certificate_location
+        if config.ssl_key_location:
+            kafka_config["ssl.key.location"] = config.ssl_key_location
+
+        self.admin_clients[config.name] = AdminClient(kafka_config)
+
+    def get_admin_client(self, cluster_name: Optional[str] = None) -> AdminClient:
+        """Get AdminClient for specified cluster or default."""
+        if cluster_name is None:
+            if len(self.admin_clients) == 1:
+                return list(self.admin_clients.values())[0]
+            elif "default" in self.admin_clients:
+                return self.admin_clients["default"]
+            else:
+                raise ValueError("Multiple clusters available, please specify cluster_name")
+
+        if cluster_name not in self.admin_clients:
+            raise ValueError(f"Cluster '{cluster_name}' not found")
+
+        return self.admin_clients[cluster_name]
+
+    def get_cluster_config(self, cluster_name: Optional[str] = None) -> KafkaClusterConfig:
+        """Get cluster configuration."""
+        if cluster_name is None:
+            if len(self.clusters) == 1:
+                return list(self.clusters.values())[0]
+            elif "default" in self.clusters:
+                return self.clusters["default"]
+            else:
+                raise ValueError("Multiple clusters available, please specify cluster_name")
+
+        if cluster_name not in self.clusters:
+            raise ValueError(f"Cluster '{cluster_name}' not found")
+
+        return self.clusters[cluster_name]
+
+    def is_viewonly(self, cluster_name: Optional[str] = None) -> bool:
+        """Check if cluster is in viewonly mode."""
+        config = self.get_cluster_config(cluster_name)
+        return config.viewonly
+
+
+def load_cluster_configurations() -> KafkaClusterManager:
+    """Load cluster configurations from environment variables."""
+    manager = KafkaClusterManager()
+
+    # Check for single cluster mode first
+    bootstrap_servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS")
+    if bootstrap_servers:
+        config = KafkaClusterConfig(
+            name="default",
+            bootstrap_servers=bootstrap_servers,
+            security_protocol=os.getenv("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT"),
+            sasl_mechanism=os.getenv("KAFKA_SASL_MECHANISM"),
+            sasl_username=os.getenv("KAFKA_SASL_USERNAME"),
+            sasl_password=os.getenv("KAFKA_SASL_PASSWORD"),
+            ssl_ca_location=os.getenv("KAFKA_SSL_CA_LOCATION"),
+            ssl_certificate_location=os.getenv("KAFKA_SSL_CERTIFICATE_LOCATION"),
+            ssl_key_location=os.getenv("KAFKA_SSL_KEY_LOCATION"),
+            viewonly=os.getenv("VIEWONLY", "false").lower() == "true",
+        )
+        manager.add_cluster(config)
+        logger.info(f"Loaded single cluster configuration: {bootstrap_servers}")
+        return manager
+
+    # Check for multi-cluster mode
+    for i in range(1, 9):  # Support up to 8 clusters
+        name = os.getenv(f"KAFKA_CLUSTER_NAME_{i}")
+        servers = os.getenv(f"KAFKA_BOOTSTRAP_SERVERS_{i}")
+
+        if name and servers:
+            config = KafkaClusterConfig(
+                name=name,
+                bootstrap_servers=servers,
+                security_protocol=os.getenv(f"KAFKA_SECURITY_PROTOCOL_{i}", "PLAINTEXT"),
+                sasl_mechanism=os.getenv(f"KAFKA_SASL_MECHANISM_{i}"),
+                sasl_username=os.getenv(f"KAFKA_SASL_USERNAME_{i}"),
+                sasl_password=os.getenv(f"KAFKA_SASL_PASSWORD_{i}"),
+                ssl_ca_location=os.getenv(f"KAFKA_SSL_CA_LOCATION_{i}"),
+                ssl_certificate_location=os.getenv(f"KAFKA_SSL_CERTIFICATE_LOCATION_{i}"),
+                ssl_key_location=os.getenv(f"KAFKA_SSL_KEY_LOCATION_{i}"),
+                viewonly=os.getenv(f"VIEWONLY_{i}", "false").lower() == "true",
+            )
+            manager.add_cluster(config)
+            logger.info(f"Loaded cluster configuration: {name} -> {servers}")
+
+    if not manager.clusters:
+        raise ValueError(
+            "No cluster configurations found. Set KAFKA_BOOTSTRAP_SERVERS or KAFKA_CLUSTER_NAME_X/KAFKA_BOOTSTRAP_SERVERS_X"
+        )
+
+    return manager

--- a/kafka_mcp_resources.py
+++ b/kafka_mcp_resources.py
@@ -1,0 +1,343 @@
+"""
+Kafka MCP Resources Module
+Defines all MCP resources (kafka:// endpoints) for cluster status, brokers, topics, etc.
+"""
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kafka_cluster_manager import KafkaClusterManager
+
+# Global cluster manager - will be set by main module
+cluster_manager: "KafkaClusterManager" = None
+
+
+def set_cluster_manager(manager: "KafkaClusterManager"):
+    """Set the global cluster manager instance."""
+    global cluster_manager
+    cluster_manager = manager
+
+
+async def get_cluster_status() -> str:
+    """Get real-time cluster status information."""
+    status = {"clusters": {}, "timestamp": time.time()}
+
+    for name, config in cluster_manager.clusters.items():
+        try:
+            admin_client = cluster_manager.get_admin_client(name)
+            metadata = admin_client.list_topics(timeout=10)
+
+            status["clusters"][name] = {
+                "name": name,
+                "bootstrap_servers": config.bootstrap_servers,
+                "viewonly": config.viewonly,
+                "topics_count": len(metadata.topics),
+                "brokers_count": len(metadata.brokers),
+                "status": "healthy",
+            }
+        except Exception as e:
+            status["clusters"][name] = {
+                "name": name,
+                "bootstrap_servers": config.bootstrap_servers,
+                "viewonly": config.viewonly,
+                "status": "error",
+                "error": str(e),
+            }
+
+    return json.dumps(status, indent=2)
+
+
+async def get_cluster_info() -> str:
+    """Get detailed cluster configuration information."""
+    info = {
+        "server_version": "1.0.0",
+        "clusters": {},
+        "configuration": {
+            "viewonly_protection": any(c.viewonly for c in cluster_manager.clusters.values()),
+            "multi_cluster_mode": len(cluster_manager.clusters) > 1,
+            "total_clusters": len(cluster_manager.clusters),
+        },
+    }
+
+    for name, config in cluster_manager.clusters.items():
+        info["clusters"][name] = {
+            "name": config.name,
+            "bootstrap_servers": config.bootstrap_servers,
+            "security_protocol": config.security_protocol,
+            "viewonly": config.viewonly,
+            "authentication": {
+                "sasl_mechanism": config.sasl_mechanism,
+                "has_credentials": bool(config.sasl_username),
+            },
+        }
+
+    return json.dumps(info, indent=2)
+
+
+async def get_brokers_resource() -> str:
+    """Get all brokers across all clusters as a resource."""
+    brokers_data = {"brokers": {}, "timestamp": time.time()}
+
+    for cluster_name in cluster_manager.clusters.keys():
+        try:
+            admin_client = cluster_manager.get_admin_client(cluster_name)
+            metadata = admin_client.list_topics(timeout=10)
+
+            brokers_data["brokers"][cluster_name] = []
+            for broker_id, broker_metadata in metadata.brokers.items():
+                brokers_data["brokers"][cluster_name].append(
+                    {
+                        "broker_id": broker_id,
+                        "host": broker_metadata.host,
+                        "port": broker_metadata.port,
+                        "rack": getattr(broker_metadata, "rack", None),
+                        "cluster": cluster_name,
+                    }
+                )
+
+        except Exception as e:
+            brokers_data["brokers"][cluster_name] = {"error": str(e), "status": "failed"}
+
+    return json.dumps(brokers_data, indent=2)
+
+
+async def get_topics_resource() -> str:
+    """Get all topics across all clusters as a resource."""
+    topics_data = {"topics": {}, "timestamp": time.time()}
+
+    for cluster_name in cluster_manager.clusters.keys():
+        try:
+            admin_client = cluster_manager.get_admin_client(cluster_name)
+            metadata = admin_client.list_topics(timeout=10)
+
+            topics_data["topics"][cluster_name] = []
+            for topic_name, topic_metadata in metadata.topics.items():
+                if not topic_name.startswith("__"):  # Filter internal topics
+                    topics_data["topics"][cluster_name].append(
+                        {
+                            "name": topic_name,
+                            "partitions": len(topic_metadata.partitions),
+                            "replication_factor": (
+                                len(topic_metadata.partitions[0].replicas) if topic_metadata.partitions else 0
+                            ),
+                            "internal": False,
+                            "cluster": cluster_name,
+                        }
+                    )
+
+        except Exception as e:
+            topics_data["topics"][cluster_name] = {"error": str(e), "status": "failed"}
+
+    return json.dumps(topics_data, indent=2)
+
+
+async def get_consumer_groups_resource() -> str:
+    """Get all consumer groups across all clusters as a resource."""
+    groups_data = {"consumer_groups": {}, "timestamp": time.time()}
+
+    for cluster_name in cluster_manager.clusters.keys():
+        try:
+            admin_client = cluster_manager.get_admin_client(cluster_name)
+            result = admin_client.list_consumer_groups(timeout=10)
+
+            groups_data["consumer_groups"][cluster_name] = []
+            for group in result.result():
+                groups_data["consumer_groups"][cluster_name].append(
+                    {
+                        "group_id": group.group_id,
+                        "is_simple_consumer_group": group.is_simple_consumer_group,
+                        "state": group.state.name if hasattr(group, "state") else "UNKNOWN",
+                        "cluster": cluster_name,
+                    }
+                )
+
+        except Exception as e:
+            groups_data["consumer_groups"][cluster_name] = {"error": str(e), "status": "failed"}
+
+    return json.dumps(groups_data, indent=2)
+
+
+async def get_partitions_resource() -> str:
+    """Get all partitions across all clusters as a resource."""
+    partitions_data = {"partitions": {}, "timestamp": time.time()}
+
+    for cluster_name in cluster_manager.clusters.keys():
+        try:
+            admin_client = cluster_manager.get_admin_client(cluster_name)
+            metadata = admin_client.list_topics(timeout=10)
+
+            partitions_data["partitions"][cluster_name] = []
+            for topic_name, topic_metadata in metadata.topics.items():
+                if not topic_name.startswith("__"):  # Filter internal topics
+                    for partition_id, partition_metadata in topic_metadata.partitions.items():
+                        partitions_data["partitions"][cluster_name].append(
+                            {
+                                "topic": topic_name,
+                                "partition_id": partition_id,
+                                "leader": partition_metadata.leader,
+                                "replicas": partition_metadata.replicas,
+                                "in_sync_replicas": partition_metadata.isrs,
+                                "error": str(partition_metadata.error) if partition_metadata.error else None,
+                                "cluster": cluster_name,
+                            }
+                        )
+
+        except Exception as e:
+            partitions_data["partitions"][cluster_name] = {"error": str(e), "status": "failed"}
+
+    return json.dumps(partitions_data, indent=2)
+
+
+async def get_cluster_brokers_resource(name: str) -> str:
+    """Get brokers for a specific cluster."""
+    try:
+        admin_client = cluster_manager.get_admin_client(name)
+        metadata = admin_client.list_topics(timeout=10)
+
+        brokers_data = {"cluster": name, "brokers": [], "timestamp": time.time()}
+
+        for broker_id, broker_metadata in metadata.brokers.items():
+            brokers_data["brokers"].append(
+                {
+                    "broker_id": broker_id,
+                    "host": broker_metadata.host,
+                    "port": broker_metadata.port,
+                    "rack": getattr(broker_metadata, "rack", None),
+                    "cluster": name,
+                }
+            )
+
+        return json.dumps(brokers_data, indent=2)
+
+    except Exception as e:
+        error_data = {"cluster": name, "error": str(e), "status": "failed", "timestamp": time.time()}
+        return json.dumps(error_data, indent=2)
+
+
+async def get_cluster_topics_resource(name: str) -> str:
+    """Get topics for a specific cluster."""
+    try:
+        admin_client = cluster_manager.get_admin_client(name)
+        metadata = admin_client.list_topics(timeout=10)
+
+        topics_data = {"cluster": name, "topics": [], "timestamp": time.time()}
+
+        for topic_name, topic_metadata in metadata.topics.items():
+            if not topic_name.startswith("__"):  # Filter internal topics
+                topics_data["topics"].append(
+                    {
+                        "name": topic_name,
+                        "partitions": len(topic_metadata.partitions),
+                        "replication_factor": len(topic_metadata.partitions[0].replicas) if topic_metadata.partitions else 0,
+                        "internal": False,
+                        "cluster": name,
+                    }
+                )
+
+        return json.dumps(topics_data, indent=2)
+
+    except Exception as e:
+        error_data = {"cluster": name, "error": str(e), "status": "failed", "timestamp": time.time()}
+        return json.dumps(error_data, indent=2)
+
+
+async def get_cluster_consumer_groups_resource(name: str) -> str:
+    """Get consumer groups for a specific cluster."""
+    try:
+        admin_client = cluster_manager.get_admin_client(name)
+        result = admin_client.list_consumer_groups(timeout=10)
+
+        groups_data = {"cluster": name, "consumer_groups": [], "timestamp": time.time()}
+
+        for group in result.result():
+            groups_data["consumer_groups"].append(
+                {
+                    "group_id": group.group_id,
+                    "is_simple_consumer_group": group.is_simple_consumer_group,
+                    "state": group.state.name if hasattr(group, "state") else "UNKNOWN",
+                    "cluster": name,
+                }
+            )
+
+        return json.dumps(groups_data, indent=2)
+
+    except Exception as e:
+        error_data = {"cluster": name, "error": str(e), "status": "failed", "timestamp": time.time()}
+        return json.dumps(error_data, indent=2)
+
+
+async def get_cluster_partitions_resource(name: str) -> str:
+    """Get partitions for a specific cluster."""
+    try:
+        admin_client = cluster_manager.get_admin_client(name)
+        metadata = admin_client.list_topics(timeout=10)
+
+        partitions_data = {"cluster": name, "partitions": [], "timestamp": time.time()}
+
+        for topic_name, topic_metadata in metadata.topics.items():
+            if not topic_name.startswith("__"):  # Filter internal topics
+                for partition_id, partition_metadata in topic_metadata.partitions.items():
+                    partitions_data["partitions"].append(
+                        {
+                            "topic": topic_name,
+                            "partition_id": partition_id,
+                            "leader": partition_metadata.leader,
+                            "replicas": partition_metadata.replicas,
+                            "in_sync_replicas": partition_metadata.isrs,
+                            "error": str(partition_metadata.error) if partition_metadata.error else None,
+                            "cluster": name,
+                        }
+                    )
+
+        return json.dumps(partitions_data, indent=2)
+
+    except Exception as e:
+        error_data = {"cluster": name, "error": str(e), "status": "failed", "timestamp": time.time()}
+        return json.dumps(error_data, indent=2)
+
+
+async def get_cluster_health_resource(name: str) -> str:
+    """Get comprehensive health information for a specific cluster."""
+    try:
+        admin_client = cluster_manager.get_admin_client(name)
+        config = cluster_manager.get_cluster_config(name)
+        metadata = admin_client.list_topics(timeout=10)
+
+        # Calculate health metrics
+        total_topics = len([t for t in metadata.topics.keys() if not t.startswith("__")])
+        total_partitions = sum(len(topic.partitions) for topic in metadata.topics.values() if not topic.name.startswith("__"))
+
+        # Check for partition issues
+        unhealthy_partitions = 0
+        for topic_metadata in metadata.topics.values():
+            if not topic_metadata.name.startswith("__"):
+                for partition_metadata in topic_metadata.partitions.values():
+                    if partition_metadata.error or len(partition_metadata.isrs) < len(partition_metadata.replicas):
+                        unhealthy_partitions += 1
+
+        health_data = {
+            "cluster": name,
+            "health_status": "healthy" if unhealthy_partitions == 0 else "degraded",
+            "cluster_info": {
+                "cluster_id": metadata.cluster_id,
+                "controller_id": metadata.controller_id,
+                "bootstrap_servers": config.bootstrap_servers,
+                "viewonly": config.viewonly,
+            },
+            "metrics": {
+                "broker_count": len(metadata.brokers),
+                "topic_count": total_topics,
+                "partition_count": total_partitions,
+                "unhealthy_partitions": unhealthy_partitions,
+                "health_percentage": round((total_partitions - unhealthy_partitions) / max(total_partitions, 1) * 100, 2),
+            },
+            "timestamp": time.time(),
+        }
+
+        return json.dumps(health_data, indent=2)
+
+    except Exception as e:
+        error_data = {"cluster": name, "error": str(e), "status": "failed", "timestamp": time.time()}
+        return json.dumps(error_data, indent=2)

--- a/kafka_mcp_tools.py
+++ b/kafka_mcp_tools.py
@@ -1,0 +1,687 @@
+"""
+Kafka MCP Tools Module
+Defines all MCP tools (@mcp.tool functions) for Kafka operations.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from confluent_kafka import Consumer, TopicPartition
+from confluent_kafka.admin import ConfigResource
+
+import kafka_mcp_resources
+from kafka_mcp_resources import get_cluster_partitions_resource, get_partitions_resource, get_cluster_health_resource
+
+if TYPE_CHECKING:
+    from kafka_cluster_manager import KafkaClusterManager
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+# Global cluster manager - will be set by main module
+cluster_manager: "KafkaClusterManager" = None
+
+
+def set_cluster_manager(manager: "KafkaClusterManager"):
+    """Set the global cluster manager instance."""
+    global cluster_manager
+    cluster_manager = manager
+
+
+async def list_clusters() -> List[Dict[str, Any]]:
+    """List all configured Kafka clusters."""
+    clusters = []
+    for name, config in cluster_manager.clusters.items():
+        try:
+            admin_client = cluster_manager.get_admin_client(name)
+            metadata = admin_client.list_topics(timeout=10)
+
+            clusters.append(
+                {
+                    "name": name,
+                    "bootstrap_servers": config.bootstrap_servers,
+                    "security_protocol": config.security_protocol,
+                    "viewonly": config.viewonly,
+                    "topics_count": len(metadata.topics),
+                    "brokers_count": len(metadata.brokers),
+                    "status": "healthy",
+                }
+            )
+        except Exception as e:
+            clusters.append(
+                {
+                    "name": name,
+                    "bootstrap_servers": config.bootstrap_servers,
+                    "viewonly": config.viewonly,
+                    "status": "error",
+                    "error": str(e),
+                }
+            )
+
+    return clusters
+
+
+async def list_topics(cluster: Optional[str] = None) -> List[Dict[str, Any]]:
+    """List all topics in the specified cluster or all clusters if none specified."""
+    try:
+        if cluster is None:
+            # Get topics from all clusters using resource
+            topics_json = await kafka_mcp_resources.get_topics_resource()
+            topics_data = json.loads(topics_json)
+
+            # Check for errors in resource response
+            if "error" in topics_data:
+                raise ValueError(f"Error getting topics: {topics_data['error']}")
+
+            all_topics = []
+            for cluster_name, cluster_topics in topics_data.get("topics", {}).items():
+                if isinstance(cluster_topics, list):
+                    all_topics.extend(cluster_topics)
+                elif isinstance(cluster_topics, dict) and "error" in cluster_topics:
+                    logger.error(f"Error getting topics from cluster '{cluster_name}': {cluster_topics['error']}")
+                    continue
+
+            return sorted(all_topics, key=lambda x: (x.get("cluster", ""), x.get("name", "")))
+        else:
+            # Get topics from specific cluster using cluster-specific resource
+            cluster_topics_json = await kafka_mcp_resources.get_cluster_topics_resource(cluster)
+            cluster_data = json.loads(cluster_topics_json)
+
+            # Check for errors in resource response
+            if "error" in cluster_data:
+                raise ValueError(f"Failed to get topics for cluster '{cluster}': {cluster_data['error']}")
+
+            topics = cluster_data.get("topics", [])
+            return sorted(topics, key=lambda x: x.get("name", ""))
+
+    except Exception as e:
+        logger.error(f"Error listing topics: {e}")
+        raise
+
+
+async def describe_topic(topic_name: str, cluster: Optional[str] = None) -> Dict[str, Any]:
+    """Get detailed information about a specific topic."""
+    try:
+        admin_client = cluster_manager.get_admin_client(cluster)
+
+        # Run in executor to avoid blocking
+        loop = asyncio.get_event_loop()
+        metadata = await loop.run_in_executor(
+            cluster_manager.executor, lambda: admin_client.list_topics(topic=topic_name, timeout=10)
+        )
+
+        if topic_name not in metadata.topics:
+            raise ValueError(f"Topic '{topic_name}' not found")
+
+        topic_metadata = metadata.topics[topic_name]
+
+        # Get topic configurations
+        config_resource = ConfigResource(ConfigResource.Type.TOPIC, topic_name)
+        configs = await loop.run_in_executor(
+            cluster_manager.executor,
+            lambda: admin_client.describe_configs([config_resource], request_timeout=10),
+        )
+
+        topic_configs = {}
+        if config_resource in configs:
+            config_result = configs[config_resource].result()
+            topic_configs = {k: v.value for k, v in config_result.items()}
+
+        # Build partition details
+        partitions = []
+        for partition_id, partition_metadata in topic_metadata.partitions.items():
+            partitions.append(
+                {
+                    "partition_id": partition_id,
+                    "leader": partition_metadata.leader,
+                    "replicas": partition_metadata.replicas,
+                    "in_sync_replicas": partition_metadata.isrs,
+                    "error": str(partition_metadata.error) if partition_metadata.error else None,
+                }
+            )
+
+        return {
+            "name": topic_name,
+            "partitions": sorted(partitions, key=lambda x: x["partition_id"]),
+            "partition_count": len(partitions),
+            "replication_factor": len(partitions[0]["replicas"]) if partitions else 0,
+            "configurations": topic_configs,
+            "internal": topic_metadata.error is not None,
+        }
+
+    except Exception as e:
+        logger.error(f"Error describing topic {topic_name}: {e}")
+        raise
+
+
+async def list_consumer_groups(cluster: Optional[str] = None) -> List[Dict[str, Any]]:
+    """List all consumer groups in the specified cluster or all clusters if none specified."""
+    try:
+        if cluster is None:
+            # Get consumer groups from all clusters using resource
+            groups_json = await kafka_mcp_resources.get_consumer_groups_resource()
+            groups_data = json.loads(groups_json)
+
+            # Check for errors in resource response
+            if "error" in groups_data:
+                raise ValueError(f"Error getting consumer groups: {groups_data['error']}")
+
+            all_groups = []
+            for cluster_name, cluster_groups in groups_data.get("consumer_groups", {}).items():
+                if isinstance(cluster_groups, list):
+                    all_groups.extend(cluster_groups)
+                elif isinstance(cluster_groups, dict) and "error" in cluster_groups:
+                    logger.error(f"Error getting consumer groups from cluster '{cluster_name}': {cluster_groups['error']}")
+                    continue
+
+            return sorted(all_groups, key=lambda x: (x.get("cluster", ""), x.get("group_id", "")))
+        else:
+            # Get consumer groups from specific cluster using cluster-specific resource
+            cluster_groups_json = await kafka_mcp_resources.get_cluster_consumer_groups_resource(cluster)
+            cluster_data = json.loads(cluster_groups_json)
+
+            # Check for errors in resource response
+            if "error" in cluster_data:
+                raise ValueError(f"Failed to get consumer groups for cluster '{cluster}': {cluster_data['error']}")
+
+            groups = cluster_data.get("consumer_groups", [])
+            return sorted(groups, key=lambda x: x.get("group_id", ""))
+
+    except Exception as e:
+        logger.error(f"Error listing consumer groups: {e}")
+        raise
+
+
+async def describe_consumer_group(group_id: str, cluster: Optional[str] = None) -> Dict[str, Any]:
+    """Get detailed information about a specific consumer group."""
+    try:
+        admin_client = cluster_manager.get_admin_client(cluster)
+
+        # Run in executor to avoid blocking
+        loop = asyncio.get_event_loop()
+
+        # Describe the consumer group
+        result = await loop.run_in_executor(
+            cluster_manager.executor, lambda: admin_client.describe_consumer_groups([group_id], timeout=10)
+        )
+
+        if group_id not in result:
+            raise ValueError(f"Consumer group '{group_id}' not found")
+
+        group_description = result[group_id].result()
+
+        # Get consumer group offsets
+        def get_offsets():
+            # Create a temporary consumer to get committed offsets
+            consumer_config = {
+                "bootstrap.servers": cluster_manager.get_cluster_config(cluster).bootstrap_servers,
+                "group.id": group_id,
+                "auto.offset.reset": "earliest",
+            }
+
+            config = cluster_manager.get_cluster_config(cluster)
+            if config.security_protocol != "PLAINTEXT":
+                consumer_config["security.protocol"] = config.security_protocol
+                if config.sasl_mechanism:
+                    consumer_config["sasl.mechanism"] = config.sasl_mechanism
+                if config.sasl_username:
+                    consumer_config["sasl.username"] = config.sasl_username
+                if config.sasl_password:
+                    consumer_config["sasl.password"] = config.sasl_password
+
+            consumer = Consumer(consumer_config)
+            try:
+                # Get list of topics this group is consuming from
+                metadata = admin_client.list_topics(timeout=10)
+                all_partitions = []
+
+                for topic_name in metadata.topics:
+                    topic_partitions = consumer.list_consumer_group_offsets([group_id], [TopicPartition(topic_name)])
+                    if topic_partitions:
+                        all_partitions.extend(topic_partitions)
+
+                committed_offsets = consumer.committed(all_partitions, timeout=10)
+                return committed_offsets
+            finally:
+                consumer.close()
+
+        offsets = await loop.run_in_executor(cluster_manager.executor, get_offsets)
+
+        # Format member information
+        members = []
+        for member in group_description.members:
+            members.append(
+                {
+                    "member_id": member.member_id,
+                    "client_id": member.client_id,
+                    "client_host": member.client_host,
+                    "assignments": (
+                        [{"topic": tp.topic, "partition": tp.partition} for tp in member.assignment.topic_partitions]
+                        if member.assignment
+                        else []
+                    ),
+                }
+            )
+
+        # Format offset information
+        offset_info = []
+        for tp in offsets:
+            if tp.offset >= 0:  # Valid offset
+                offset_info.append(
+                    {
+                        "topic": tp.topic,
+                        "partition": tp.partition,
+                        "current_offset": tp.offset,
+                        "metadata": tp.metadata,
+                    }
+                )
+
+        return {
+            "group_id": group_id,
+            "state": group_description.state.name,
+            "protocol_type": group_description.protocol_type,
+            "protocol": group_description.protocol,
+            "coordinator": {
+                "id": group_description.coordinator.id,
+                "host": group_description.coordinator.host,
+                "port": group_description.coordinator.port,
+            },
+            "members": members,
+            "member_count": len(members),
+            "offsets": offset_info,
+        }
+
+    except Exception as e:
+        logger.error(f"Error describing consumer group {group_id}: {e}")
+        raise
+
+
+async def list_brokers(cluster: Optional[str] = None) -> List[Dict[str, Any]]:
+    """List all brokers in the specified cluster or all clusters if none specified."""
+    try:
+        if cluster is None:
+            # Get brokers from all clusters using resource
+            brokers_json = await kafka_mcp_resources.get_brokers_resource()
+            brokers_data = json.loads(brokers_json)
+
+            # Check for errors in resource response
+            if "error" in brokers_data:
+                raise ValueError(f"Error getting brokers: {brokers_data['error']}")
+
+            all_brokers = []
+            for cluster_name, cluster_brokers in brokers_data.get("brokers", {}).items():
+                if isinstance(cluster_brokers, list):
+                    all_brokers.extend(cluster_brokers)
+                elif isinstance(cluster_brokers, dict) and "error" in cluster_brokers:
+                    logger.error(f"Error getting brokers from cluster '{cluster_name}': {cluster_brokers['error']}")
+                    continue
+
+            return sorted(all_brokers, key=lambda x: (x.get("cluster", ""), x.get("broker_id", 0)))
+        else:
+            # Get brokers from specific cluster using cluster-specific resource
+            cluster_brokers_json = await kafka_mcp_resources.get_cluster_brokers_resource(cluster)
+            cluster_data = json.loads(cluster_brokers_json)
+
+            # Check for errors in resource response
+            if "error" in cluster_data:
+                raise ValueError(f"Failed to get brokers for cluster '{cluster}': {cluster_data['error']}")
+
+            brokers = cluster_data.get("brokers", [])
+            return sorted(brokers, key=lambda x: x.get("broker_id", 0))
+
+    except Exception as e:
+        logger.error(f"Error listing brokers: {e}")
+        raise
+
+
+async def get_cluster_metadata(cluster: Optional[str] = None) -> Dict[str, Any]:
+    """Get comprehensive cluster metadata and information."""
+    try:
+        admin_client = cluster_manager.get_admin_client(cluster)
+        config = cluster_manager.get_cluster_config(cluster)
+
+        # Run in executor to avoid blocking
+        loop = asyncio.get_event_loop()
+        metadata = await loop.run_in_executor(cluster_manager.executor, lambda: admin_client.list_topics(timeout=10))
+
+        # Count topics (excluding internal ones)
+        user_topics = [name for name in metadata.topics.keys() if not name.startswith("__")]
+        internal_topics = [name for name in metadata.topics.keys() if name.startswith("__")]
+
+        # Calculate total partitions
+        total_partitions = sum(len(topic.partitions) for topic in metadata.topics.values())
+
+        return {
+            "cluster_name": config.name,
+            "bootstrap_servers": config.bootstrap_servers,
+            "viewonly": config.viewonly,
+            "cluster_id": metadata.cluster_id,
+            "controller_id": metadata.controller_id,
+            "brokers": {"count": len(metadata.brokers), "ids": list(metadata.brokers.keys())},
+            "topics": {
+                "total": len(metadata.topics),
+                "user_topics": len(user_topics),
+                "internal_topics": len(internal_topics),
+                "total_partitions": total_partitions,
+            },
+            "security": {
+                "protocol": config.security_protocol,
+                "sasl_mechanism": config.sasl_mechanism,
+                "authentication_enabled": bool(config.sasl_username),
+            },
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting cluster metadata: {e}")
+        raise
+
+
+async def get_partitions(cluster: Optional[str] = None, topic: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Get partitions from kafka://partitions resource or cluster-specific resource."""
+    try:
+        if cluster:
+            # Use cluster-specific resource
+            partitions_resource = await kafka_mcp_resources.get_cluster_partitions_resource(cluster)
+            partitions_data = json.loads(partitions_resource)
+
+            if "error" in partitions_data:
+                raise ValueError(f"Failed to get partitions for cluster '{cluster}': {partitions_data['error']}")
+
+            all_partitions = partitions_data.get("partitions", [])
+        else:
+            # Use global resource
+            partitions_resource = await kafka_mcp_resources.get_partitions_resource()
+            partitions_data = json.loads(partitions_resource)
+
+            # Check for errors in resource response
+            if "error" in partitions_data:
+                raise ValueError(f"Error getting partitions: {partitions_data['error']}")
+
+            all_partitions = []
+            for cluster_name, cluster_partitions in partitions_data.get("partitions", {}).items():
+                if isinstance(cluster_partitions, list):
+                    all_partitions.extend(cluster_partitions)
+                elif isinstance(cluster_partitions, dict) and "error" in cluster_partitions:
+                    logger.error(f"Error getting partitions from cluster '{cluster_name}': {cluster_partitions['error']}")
+                    continue
+
+        # Filter by topic if specified
+        if topic:
+            all_partitions = [p for p in all_partitions if p["topic"] == topic]
+
+        return sorted(all_partitions, key=lambda x: (x["topic"], x["partition_id"]))
+
+    except Exception as e:
+        logger.error(f"Error getting partitions: {e}")
+        raise
+
+
+async def get_cluster_health(cluster: str) -> Dict[str, Any]:
+    """Get comprehensive health information for a specific cluster."""
+    try:
+        health_resource = await kafka_mcp_resources.get_cluster_health_resource(cluster)
+        health_data = json.loads(health_resource)
+
+        if "error" in health_data:
+            raise ValueError(f"Failed to get health for cluster '{cluster}': {health_data['error']}")
+
+        return health_data
+
+    except Exception as e:
+        logger.error(f"Error getting cluster health: {e}")
+        raise
+
+
+async def compare_cluster_topics(source_cluster: str, target_cluster: str) -> Dict[str, Any]:
+    """Compare topics between two clusters."""
+    try:
+        # Get topics from both clusters
+        source_topics = await list_topics(cluster=source_cluster)
+        target_topics = await list_topics(cluster=target_cluster)
+
+        # Create topic name sets
+        source_names = {topic["name"] for topic in source_topics}
+        target_names = {topic["name"] for topic in target_topics}
+
+        # Find differences
+        only_in_source = source_names - target_names
+        only_in_target = target_names - source_names
+        common_topics = source_names & target_names
+
+        # Compare common topics
+        topic_differences = []
+        source_topics_dict = {t["name"]: t for t in source_topics}
+        target_topics_dict = {t["name"]: t for t in target_topics}
+
+        for topic_name in common_topics:
+            source_topic = source_topics_dict[topic_name]
+            target_topic = target_topics_dict[topic_name]
+
+            differences = {}
+            if source_topic["partitions"] != target_topic["partitions"]:
+                differences["partitions"] = {"source": source_topic["partitions"], "target": target_topic["partitions"]}
+            if source_topic["replication_factor"] != target_topic["replication_factor"]:
+                differences["replication_factor"] = {
+                    "source": source_topic["replication_factor"],
+                    "target": target_topic["replication_factor"],
+                }
+
+            if differences:
+                topic_differences.append({"topic": topic_name, "differences": differences})
+
+        return {
+            "source_cluster": source_cluster,
+            "target_cluster": target_cluster,
+            "summary": {
+                "total_source_topics": len(source_names),
+                "total_target_topics": len(target_names),
+                "common_topics": len(common_topics),
+                "only_in_source": len(only_in_source),
+                "only_in_target": len(only_in_target),
+                "topics_with_differences": len(topic_differences),
+            },
+            "only_in_source": sorted(list(only_in_source)),
+            "only_in_target": sorted(list(only_in_target)),
+            "topic_differences": topic_differences,
+        }
+
+    except Exception as e:
+        logger.error(f"Error comparing cluster topics: {e}")
+        raise
+
+
+async def get_partition_leaders(cluster_name: str) -> Dict[str, Any]:
+    """Get partition leader distribution across brokers for a cluster."""
+    try:
+        partitions = await get_partitions(cluster=cluster_name)
+        brokers = await list_brokers(cluster=cluster_name)
+
+        # Count partitions by leader
+        leader_counts = {}
+        for partition in partitions:
+            leader_id = partition["leader"]
+            if leader_id not in leader_counts:
+                leader_counts[leader_id] = {"broker_id": leader_id, "partition_count": 0, "topics": {}}
+
+            leader_counts[leader_id]["partition_count"] += 1
+            topic_name = partition["topic"]
+            if topic_name not in leader_counts[leader_id]["topics"]:
+                leader_counts[leader_id]["topics"][topic_name] = 0
+            leader_counts[leader_id]["topics"][topic_name] += 1
+
+        # Add broker details
+        brokers_dict = {b["broker_id"]: b for b in brokers}
+        for leader_id, leader_info in leader_counts.items():
+            if leader_id in brokers_dict:
+                broker = brokers_dict[leader_id]
+                leader_info["host"] = broker["host"]
+                leader_info["port"] = broker["port"]
+                leader_info["rack"] = broker.get("rack")
+
+        return {
+            "cluster": cluster_name,
+            "total_partitions": len(partitions),
+            "total_brokers": len(brokers),
+            "leader_distribution": list(leader_counts.values()),
+            "balance_ratio": (
+                min(leader_counts.values(), key=lambda x: x["partition_count"])["partition_count"]
+                / max(leader_counts.values(), key=lambda x: x["partition_count"])["partition_count"]
+                if leader_counts
+                else 0
+            ),
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting partition leaders: {e}")
+        raise
+
+
+async def get_topic_partition_details(cluster_name: str, topic_name: str) -> Dict[str, Any]:
+    """Get detailed partition information for a specific topic."""
+    try:
+        admin_client = cluster_manager.get_admin_client(cluster_name)
+
+        # Run in executor to avoid blocking
+        loop = asyncio.get_event_loop()
+        metadata = await loop.run_in_executor(
+            cluster_manager.executor, lambda: admin_client.list_topics(topic=topic_name, timeout=10)
+        )
+
+        if topic_name not in metadata.topics:
+            raise ValueError(f"Topic '{topic_name}' not found in cluster '{cluster_name}'")
+
+        topic_metadata = metadata.topics[topic_name]
+
+        # Get brokers info for enrichment
+        brokers_dict = {b["broker_id"]: b for b in await list_brokers(cluster=cluster_name)}
+
+        # Build detailed partition info
+        partitions_detail = []
+        for partition_id, partition_metadata in topic_metadata.partitions.items():
+            leader_broker = brokers_dict.get(partition_metadata.leader, {})
+
+            replica_brokers = []
+            for replica_id in partition_metadata.replicas:
+                broker = brokers_dict.get(replica_id, {})
+                replica_brokers.append(
+                    {
+                        "broker_id": replica_id,
+                        "host": broker.get("host", "unknown"),
+                        "port": broker.get("port", 0),
+                        "in_sync": replica_id in partition_metadata.isrs,
+                    }
+                )
+
+            partitions_detail.append(
+                {
+                    "partition_id": partition_id,
+                    "leader": {
+                        "broker_id": partition_metadata.leader,
+                        "host": leader_broker.get("host", "unknown"),
+                        "port": leader_broker.get("port", 0),
+                    },
+                    "replicas": replica_brokers,
+                    "replication_factor": len(partition_metadata.replicas),
+                    "in_sync_replicas_count": len(partition_metadata.isrs),
+                    "is_healthy": len(partition_metadata.isrs) == len(partition_metadata.replicas),
+                    "error": str(partition_metadata.error) if partition_metadata.error else None,
+                }
+            )
+
+        # Calculate topic health
+        healthy_partitions = sum(1 for p in partitions_detail if p["is_healthy"])
+
+        return {
+            "cluster": cluster_name,
+            "topic": topic_name,
+            "partition_count": len(partitions_detail),
+            "replication_factor": len(partitions_detail[0]["replicas"]) if partitions_detail else 0,
+            "health": {
+                "healthy_partitions": healthy_partitions,
+                "unhealthy_partitions": len(partitions_detail) - healthy_partitions,
+                "health_percentage": round(healthy_partitions / len(partitions_detail) * 100, 2) if partitions_detail else 0,
+            },
+            "partitions": sorted(partitions_detail, key=lambda x: x["partition_id"]),
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting topic partition details: {e}")
+        raise
+
+
+async def find_under_replicated_partitions(cluster_name: str) -> List[Dict[str, Any]]:
+    """Find partitions that are under-replicated (fewer ISRs than replicas)."""
+    try:
+        partitions = await get_partitions(cluster=cluster_name)
+
+        under_replicated = []
+        for partition in partitions:
+            isr_count = len(partition["in_sync_replicas"])
+            replica_count = len(partition["replicas"])
+
+            if isr_count < replica_count:
+                under_replicated.append(
+                    {
+                        "topic": partition["topic"],
+                        "partition_id": partition["partition_id"],
+                        "leader": partition["leader"],
+                        "replicas": partition["replicas"],
+                        "in_sync_replicas": partition["in_sync_replicas"],
+                        "missing_replicas": replica_count - isr_count,
+                        "replication_factor": replica_count,
+                        "cluster": cluster_name,
+                    }
+                )
+
+        return sorted(under_replicated, key=lambda x: (x["topic"], x["partition_id"]))
+
+    except Exception as e:
+        logger.error(f"Error finding under-replicated partitions: {e}")
+        raise
+
+
+async def get_broker_partition_count(cluster_name: str) -> List[Dict[str, Any]]:
+    """Get partition count per broker for load balancing analysis."""
+    try:
+        partitions = await get_partitions(cluster=cluster_name)
+        brokers = await list_brokers(cluster=cluster_name)
+
+        # Count partitions per broker (as leader and as replica)
+        broker_stats = {}
+        for broker in brokers:
+            broker_id = broker["broker_id"]
+            broker_stats[broker_id] = {
+                "broker_id": broker_id,
+                "host": broker["host"],
+                "port": broker["port"],
+                "rack": broker.get("rack"),
+                "leader_count": 0,
+                "replica_count": 0,
+                "topics": set(),
+            }
+
+        for partition in partitions:
+            # Count leader partitions
+            leader_id = partition["leader"]
+            if leader_id in broker_stats:
+                broker_stats[leader_id]["leader_count"] += 1
+                broker_stats[leader_id]["topics"].add(partition["topic"])
+
+            # Count replica partitions
+            for replica_id in partition["replicas"]:
+                if replica_id in broker_stats:
+                    broker_stats[replica_id]["replica_count"] += 1
+                    broker_stats[replica_id]["topics"].add(partition["topic"])
+
+        # Convert topics set to count
+        for stats in broker_stats.values():
+            stats["topic_count"] = len(stats["topics"])
+            del stats["topics"]  # Remove the set as it's not JSON serializable
+
+        return sorted(broker_stats.values(), key=lambda x: x["broker_id"])
+
+    except Exception as e:
+        logger.error(f"Error getting broker partition count: {e}")
+        raise

--- a/tests/test_basic_server.py
+++ b/tests/test_basic_server.py
@@ -19,7 +19,7 @@ import pytest
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from kafka_brokers_unified_mcp import (
+from kafka_cluster_manager import (
     KafkaClusterConfig, 
     KafkaClusterManager, 
     load_cluster_configurations

--- a/tests/test_cluster_specific_resources_and_tools.py
+++ b/tests/test_cluster_specific_resources_and_tools.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""
+Tests for cluster-specific MCP resources and advanced tools
+Tests the cluster-specific kafka://{name} resources and advanced analysis tools.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+from typing import Dict, List, Any
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from kafka_cluster_manager import (
+    KafkaClusterConfig,
+    KafkaClusterManager
+)
+from kafka_mcp_resources import (
+    get_cluster_brokers_resource,
+    get_cluster_topics_resource,
+    get_cluster_consumer_groups_resource,
+    get_cluster_partitions_resource,
+    get_cluster_health_resource
+)
+from kafka_mcp_tools import (
+    get_partitions,
+    get_cluster_health,
+    compare_cluster_topics,
+    get_partition_leaders,
+    get_topic_partition_details,
+    find_under_replicated_partitions,
+    get_broker_partition_count,
+    list_topics,
+    list_brokers
+)
+import kafka_mcp_tools
+import kafka_mcp_resources
+
+
+class TestClusterSpecificResources:
+    """Test cluster-specific MCP resources."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.manager = KafkaClusterManager()
+        
+        # Initialize cluster_manager in the imported modules
+        kafka_mcp_tools.set_cluster_manager(self.manager)
+        kafka_mcp_resources.set_cluster_manager(self.manager)
+        
+        # Add test cluster
+        cluster_config = KafkaClusterConfig(
+            name="production",
+            bootstrap_servers="localhost:9092"
+        )
+        self.manager.clusters = {
+            "production": cluster_config
+        }
+
+    def create_mock_metadata(self, cluster_name="production"):
+        """Create mock Kafka metadata for testing."""
+        mock_metadata = MagicMock()
+        mock_metadata.cluster_id = f"kafka-cluster-{cluster_name}"
+        mock_metadata.controller_id = 1
+        
+        # Mock brokers
+        mock_broker = MagicMock()
+        mock_broker.host = f"{cluster_name}-kafka-1"
+        mock_broker.port = 9092
+        mock_broker.rack = "rack-1"
+        mock_metadata.brokers = {1: mock_broker, 2: MagicMock(host=f"{cluster_name}-kafka-2", port=9092, rack="rack-2")}
+        
+        # Mock topics with partitions
+        mock_topic = MagicMock()
+        mock_partition1 = MagicMock()
+        mock_partition1.leader = 1
+        mock_partition1.replicas = [1, 2, 3]
+        mock_partition1.isrs = [1, 2, 3]
+        mock_partition1.error = None
+        
+        mock_partition2 = MagicMock()
+        mock_partition2.leader = 2
+        mock_partition2.replicas = [2, 1, 3]
+        mock_partition2.isrs = [2, 1]  # Under-replicated
+        mock_partition2.error = None
+        
+        mock_topic.partitions = {0: mock_partition1, 1: mock_partition2}
+        mock_metadata.topics = {"user-events": mock_topic, "order-updates": mock_topic}
+        
+        return mock_metadata
+
+    def create_mock_consumer_groups(self):
+        """Create mock consumer groups for testing."""
+        mock_group = MagicMock()
+        mock_group.group_id = "analytics-service"
+        mock_group.is_simple_consumer_group = False
+        mock_group.state = MagicMock()
+        mock_group.state.name = "STABLE"
+        
+        mock_result = MagicMock()
+        mock_result.result.return_value = [mock_group]
+        
+        return mock_result
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_cluster_brokers_resource(self, mock_cluster_manager):
+        """Test kafka://brokers/{name} resource."""
+        # Mock admin client
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.return_value = self.create_mock_metadata("production")
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        result_json = await get_cluster_brokers_resource("production")
+        result = json.loads(result_json)
+        
+        # Verify structure
+        assert "cluster" in result
+        assert "brokers" in result
+        assert "timestamp" in result
+        assert result["cluster"] == "production"
+        assert isinstance(result["brokers"], list)
+        assert len(result["brokers"]) == 2
+        
+        # Verify broker data
+        broker = result["brokers"][0]
+        assert "broker_id" in broker
+        assert "host" in broker
+        assert "port" in broker
+        assert "cluster" in broker
+        assert broker["cluster"] == "production"
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_cluster_topics_resource(self, mock_cluster_manager):
+        """Test kafka://topics/{name} resource."""
+        # Mock admin client
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.return_value = self.create_mock_metadata("production")
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        result_json = await get_cluster_topics_resource("production")
+        result = json.loads(result_json)
+        
+        # Verify structure
+        assert "cluster" in result
+        assert "topics" in result
+        assert "timestamp" in result
+        assert result["cluster"] == "production"
+        assert isinstance(result["topics"], list)
+        assert len(result["topics"]) == 2
+        
+        # Verify topic data
+        topic = result["topics"][0]
+        assert "name" in topic
+        assert "partitions" in topic
+        assert "cluster" in topic
+        assert topic["cluster"] == "production"
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_cluster_health_resource(self, mock_cluster_manager):
+        """Test kafka://cluster-health/{name} resource."""
+        # Mock admin client and config
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.return_value = self.create_mock_metadata("production")
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        mock_config = MagicMock()
+        mock_config.bootstrap_servers = "prod-kafka:9092"
+        mock_config.viewonly = True
+        mock_cluster_manager.get_cluster_config.return_value = mock_config
+        
+        result_json = await get_cluster_health_resource("production")
+        result = json.loads(result_json)
+        
+        # Verify structure
+        assert "cluster" in result
+        assert "health_status" in result
+        assert "cluster_info" in result
+        assert "metrics" in result
+        assert "timestamp" in result
+        
+        # Verify health metrics
+        assert result["health_status"] in ["healthy", "degraded"]
+        assert "broker_count" in result["metrics"]
+        assert "topic_count" in result["metrics"]
+        assert "partition_count" in result["metrics"]
+        assert "health_percentage" in result["metrics"]
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_cluster_resource_error_handling(self, mock_cluster_manager):
+        """Test error handling in cluster-specific resources."""
+        # Mock cluster manager with error
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.side_effect = Exception("Connection failed")
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        result_json = await get_cluster_brokers_resource("production")
+        result = json.loads(result_json)
+        
+        # Should have error information
+        assert "cluster" in result
+        assert "error" in result
+        assert "status" in result
+        assert result["cluster"] == "production"
+        assert result["status"] == "failed"
+
+
+class TestClusterSpecificTools:
+    """Test cluster-specific tools."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.manager = KafkaClusterManager()
+        
+        # Initialize cluster_manager in the imported modules
+        kafka_mcp_tools.set_cluster_manager(self.manager)
+        kafka_mcp_resources.set_cluster_manager(self.manager)
+        
+        # Add test cluster
+        cluster_config = KafkaClusterConfig(
+            name="production",
+            bootstrap_servers="localhost:9092"
+        )
+        self.manager.clusters = {
+            "production": cluster_config
+        }
+
+    @patch('kafka_mcp_resources.get_cluster_brokers_resource')
+    @pytest.mark.asyncio
+    async def test_get_brokers_tool_with_cluster(self, mock_resource):
+        """Test get_brokers tool with cluster parameter."""
+        mock_resource.return_value = json.dumps({
+            "cluster": "production",
+            "brokers": [
+                {"broker_id": 1, "host": "prod-kafka-1", "port": 9092, "cluster": "production"}
+            ]
+        })
+        
+        result = await list_brokers(cluster="production")
+        
+        assert len(result) == 1
+        assert result[0]["cluster"] == "production"
+        assert result[0]["broker_id"] == 1
+
+    @patch('kafka_mcp_resources.get_cluster_topics_resource')
+    @pytest.mark.asyncio
+    async def test_get_topics_tool_with_cluster(self, mock_resource):
+        """Test get_topics tool with cluster parameter."""
+        mock_resource.return_value = json.dumps({
+            "cluster": "production",
+            "topics": [
+                {"name": "user-events", "partitions": 6, "cluster": "production"}
+            ]
+        })
+        
+        result = await list_topics(cluster="production")
+        
+        assert len(result) == 1
+        assert result[0]["name"] == "user-events"
+        assert result[0]["cluster"] == "production"
+
+    @patch('kafka_mcp_resources.get_cluster_partitions_resource')
+    @pytest.mark.asyncio
+    async def test_get_cluster_partitions_with_topic_filter(self, mock_resource):
+        """Test get_cluster_partitions tool with topic filter."""
+        mock_resource.return_value = json.dumps({
+            "cluster": "production",
+            "partitions": [
+                {"topic": "user-events", "partition_id": 0, "cluster": "production"},
+                {"topic": "user-events", "partition_id": 1, "cluster": "production"},
+                {"topic": "order-updates", "partition_id": 0, "cluster": "production"}
+            ]
+        })
+        
+        result = await get_partitions(cluster="production", topic="user-events")
+        
+        # Should return only user-events partitions
+        assert len(result) == 2
+        for partition in result:
+            assert partition["topic"] == "user-events"
+
+    @patch('kafka_mcp_resources.get_cluster_health_resource')
+    @pytest.mark.asyncio
+    async def test_get_cluster_health_tool(self, mock_resource):
+        """Test get_cluster_health tool."""
+        mock_resource.return_value = json.dumps({
+            "cluster": "production",
+            "health_status": "healthy",
+            "metrics": {
+                "broker_count": 3,
+                "topic_count": 15,
+                "partition_count": 120,
+                "unhealthy_partitions": 0,
+                "health_percentage": 100.0
+            }
+        })
+        
+        result = await get_cluster_health("production")
+        
+        assert result["health_status"] == "healthy"
+        assert result["metrics"]["health_percentage"] == 100.0
+
+    @patch('kafka_brokers_unified_mcp.get_cluster_brokers_resource')
+    @pytest.mark.asyncio
+    async def test_cluster_tool_error_handling(self, mock_resource):
+        """Test error handling in cluster tools."""
+        mock_resource.return_value = json.dumps({
+            "cluster": "production",
+            "error": "Connection failed",
+            "status": "failed"
+        })
+        
+        with pytest.raises(ValueError, match="Failed to get brokers for cluster 'production'"):
+            await list_brokers(cluster="production")
+
+
+class TestAdvancedAnalysisTools:
+    """Test advanced analysis and monitoring tools."""
+
+    def setup_method(self):
+        """Set up test fixtures.""" 
+        self.manager = KafkaClusterManager()
+        
+        # Initialize cluster_manager in the imported modules
+        kafka_mcp_tools.set_cluster_manager(self.manager)
+        kafka_mcp_resources.set_cluster_manager(self.manager)
+        
+        # Add test clusters
+        dev_config = KafkaClusterConfig(
+            name="development",
+            bootstrap_servers="localhost:9092"
+        )
+        prod_config = KafkaClusterConfig(
+            name="production",
+            bootstrap_servers="localhost:9093"
+        )
+        self.manager.clusters = {
+            "development": dev_config,
+            "production": prod_config
+        }
+
+    @patch('kafka_mcp_tools.list_topics')
+    @pytest.mark.asyncio
+    async def test_compare_cluster_topics(self, mock_get_topics):
+        """Test compare_cluster_topics tool."""
+        def mock_topics(cluster):
+            if cluster == "development":
+                return [
+                    {"name": "user-events", "partitions": 3, "replication_factor": 2},
+                    {"name": "shared-topic", "partitions": 1, "replication_factor": 1}
+                ]
+            else:  # production
+                return [
+                    {"name": "user-events", "partitions": 6, "replication_factor": 3},
+                    {"name": "shared-topic", "partitions": 1, "replication_factor": 1},
+                    {"name": "prod-only-topic", "partitions": 3, "replication_factor": 3}
+                ]
+        
+        mock_get_topics.side_effect = mock_topics
+        
+        result = await compare_cluster_topics("development", "production")
+        
+        # Verify comparison structure
+        assert "source_cluster" in result
+        assert "target_cluster" in result
+        assert "summary" in result
+        assert "only_in_source" in result
+        assert "only_in_target" in result
+        assert "topic_differences" in result
+        
+        # Verify summary
+        summary = result["summary"]
+        assert summary["total_source_topics"] == 2
+        assert summary["total_target_topics"] == 3
+        assert summary["common_topics"] == 2
+        assert summary["only_in_target"] == 1
+        
+        # Verify differences
+        assert "prod-only-topic" in result["only_in_target"]
+        assert len(result["topic_differences"]) == 1
+        assert result["topic_differences"][0]["topic"] == "user-events"
+
+    @patch('kafka_mcp_tools.get_partitions')
+    @patch('kafka_mcp_tools.list_brokers')
+    @pytest.mark.asyncio
+    async def test_get_partition_leaders(self, mock_brokers, mock_partitions):
+        """Test get_partition_leaders tool."""
+        mock_brokers.return_value = [
+            {"broker_id": 1, "host": "kafka-1", "port": 9092},
+            {"broker_id": 2, "host": "kafka-2", "port": 9092}
+        ]
+        
+        mock_partitions.return_value = [
+            {"topic": "user-events", "partition_id": 0, "leader": 1},
+            {"topic": "user-events", "partition_id": 1, "leader": 1},
+            {"topic": "user-events", "partition_id": 2, "leader": 2},
+            {"topic": "order-updates", "partition_id": 0, "leader": 2}
+        ]
+        
+        result = await get_partition_leaders("production")
+        
+        # Verify structure
+        assert "cluster" in result
+        assert "total_partitions" in result
+        assert "total_brokers" in result
+        assert "leader_distribution" in result
+        assert "balance_ratio" in result
+        
+        # Verify leader distribution
+        leader_dist = result["leader_distribution"]
+        assert len(leader_dist) == 2
+        
+        # Check broker 1 has 2 partitions as leader
+        broker1_info = next(b for b in leader_dist if b["broker_id"] == 1)
+        assert broker1_info["partition_count"] == 2
+
+    @patch('kafka_mcp_tools.get_partitions')
+    @pytest.mark.asyncio
+    async def test_find_under_replicated_partitions(self, mock_partitions):
+        """Test find_under_replicated_partitions tool."""
+        mock_partitions.return_value = [
+            {
+                "topic": "user-events",
+                "partition_id": 0,
+                "leader": 1,
+                "replicas": [1, 2, 3],
+                "in_sync_replicas": [1, 2, 3]  # Healthy
+            },
+            {
+                "topic": "user-events", 
+                "partition_id": 1,
+                "leader": 1,
+                "replicas": [1, 2, 3],
+                "in_sync_replicas": [1, 2]  # Under-replicated
+            },
+            {
+                "topic": "order-updates",
+                "partition_id": 0,
+                "leader": 1,
+                "replicas": [1, 2],
+                "in_sync_replicas": [1]  # Under-replicated
+            }
+        ]
+        
+        result = await find_under_replicated_partitions("production")
+        
+        # Should find 2 under-replicated partitions
+        assert len(result) == 2
+        
+        # Verify structure
+        under_rep = result[0]
+        assert "topic" in under_rep
+        assert "partition_id" in under_rep
+        assert "missing_replicas" in under_rep
+        assert "replication_factor" in under_rep
+        assert "cluster" in under_rep
+        
+        # Verify calculations
+        assert under_rep["missing_replicas"] > 0
+
+    @patch('kafka_mcp_tools.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_topic_partition_details(self, mock_cluster_manager):
+        """Test get_topic_partition_details tool."""
+        # Mock admin client
+        mock_admin_client = MagicMock()
+        
+        # Mock metadata for specific topic
+        mock_metadata = MagicMock()
+        mock_topic = MagicMock()
+        
+        mock_partition = MagicMock()
+        mock_partition.leader = 1
+        mock_partition.replicas = [1, 2, 3]
+        mock_partition.isrs = [1, 2, 3]
+        mock_partition.error = None
+        
+        mock_topic.partitions = {0: mock_partition}
+        mock_metadata.topics = {"user-events": mock_topic}
+        
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        mock_cluster_manager.executor = MagicMock()
+        
+        # Mock the list_brokers call
+        with patch('kafka_mcp_tools.list_brokers') as mock_brokers:
+            mock_brokers.return_value = [
+                {"broker_id": 1, "host": "kafka-1", "port": 9092},
+                {"broker_id": 2, "host": "kafka-2", "port": 9092},
+                {"broker_id": 3, "host": "kafka-3", "port": 9092}
+            ]
+            
+            # Mock the executor.run_in_executor call
+            async def mock_run_in_executor(executor, func):
+                return mock_metadata
+            
+            with patch('asyncio.get_event_loop') as mock_loop:
+                mock_loop.return_value.run_in_executor = mock_run_in_executor
+                
+                result = await get_topic_partition_details("production", "user-events")
+                
+                # Verify structure
+                assert "cluster" in result
+                assert "topic" in result
+                assert "partition_count" in result
+                assert "health" in result
+                assert "partitions" in result
+                
+                # Verify health calculation
+                assert result["health"]["healthy_partitions"] == 1
+                assert result["health"]["health_percentage"] == 100.0
+
+    @patch('kafka_mcp_tools.get_partitions')
+    @patch('kafka_mcp_tools.list_brokers')
+    @pytest.mark.asyncio
+    async def test_get_broker_partition_count(self, mock_brokers, mock_partitions):
+        """Test get_broker_partition_count tool."""
+        mock_brokers.return_value = [
+            {"broker_id": 1, "host": "kafka-1", "port": 9092, "rack": "rack-1"},
+            {"broker_id": 2, "host": "kafka-2", "port": 9092, "rack": "rack-2"}
+        ]
+        
+        mock_partitions.return_value = [
+            {"topic": "user-events", "leader": 1, "replicas": [1, 2]},
+            {"topic": "user-events", "leader": 2, "replicas": [2, 1]},
+            {"topic": "order-updates", "leader": 1, "replicas": [1, 2]}
+        ]
+        
+        result = await get_broker_partition_count("production")
+        
+        # Should return stats for both brokers
+        assert len(result) == 2
+        
+        # Verify structure
+        broker_stats = result[0]
+        assert "broker_id" in broker_stats
+        assert "host" in broker_stats
+        assert "leader_count" in broker_stats
+        assert "replica_count" in broker_stats
+        assert "topic_count" in broker_stats
+        
+        # Verify counts (broker 1 should have 2 leader partitions)
+        broker1_stats = next(b for b in result if b["broker_id"] == 1)
+        assert broker1_stats["leader_count"] == 2
+        assert broker1_stats["replica_count"] == 3  # 3 total replica assignments
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"]) 

--- a/tests/test_consumer_group_operations.py
+++ b/tests/test_consumer_group_operations.py
@@ -15,7 +15,7 @@ import pytest
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from kafka_brokers_unified_mcp import (
+from kafka_cluster_manager import (
     KafkaClusterManager, 
     load_cluster_configurations
 )

--- a/tests/test_multi_cluster_mcp.py
+++ b/tests/test_multi_cluster_mcp.py
@@ -15,7 +15,7 @@ import pytest
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from kafka_brokers_unified_mcp import (
+from kafka_cluster_manager import (
     KafkaClusterConfig, 
     KafkaClusterManager, 
     load_cluster_configurations

--- a/tests/test_new_resources_and_tools.py
+++ b/tests/test_new_resources_and_tools.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""
+Tests for new MCP resources and tools
+Tests the new kafka:// resources and corresponding get_ tools added in the latest version.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+from typing import Dict, List, Any
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from kafka_cluster_manager import (
+    KafkaClusterConfig,
+    KafkaClusterManager,
+    load_cluster_configurations
+)
+from kafka_mcp_resources import (
+    get_brokers_resource,
+    get_topics_resource,
+    get_consumer_groups_resource,
+    get_partitions_resource
+)
+from kafka_mcp_tools import (
+    get_partitions,
+    list_topics,
+    list_brokers,
+    list_consumer_groups
+)
+import kafka_mcp_tools
+import kafka_mcp_resources
+
+
+class TestNewResources:
+    """Test the new MCP resources."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.manager = KafkaClusterManager()
+        
+        # Initialize cluster_manager in the imported modules
+        kafka_mcp_tools.set_cluster_manager(self.manager)
+        kafka_mcp_resources.set_cluster_manager(self.manager)
+        
+        # Add test clusters
+        self.manager.add_cluster(KafkaClusterConfig(
+            name="test-cluster-1",
+            bootstrap_servers="localhost:9092",
+            viewonly=False
+        ))
+        
+        self.manager.add_cluster(KafkaClusterConfig(
+            name="test-cluster-2", 
+            bootstrap_servers="localhost:9093",
+            viewonly=True
+        ))
+
+    def create_mock_metadata(self, cluster_name="test-cluster-1"):
+        """Create mock Kafka metadata for testing."""
+        mock_metadata = MagicMock()
+        
+        # Mock brokers
+        mock_broker = MagicMock()
+        mock_broker.host = "localhost"
+        mock_broker.port = 9092
+        mock_broker.rack = None
+        mock_metadata.brokers = {1: mock_broker}
+        
+        # Mock topics with partitions
+        mock_topic = MagicMock()
+        mock_partition = MagicMock()
+        mock_partition.leader = 1
+        mock_partition.replicas = [1, 2, 3]
+        mock_partition.isrs = [1, 2, 3]
+        mock_partition.error = None
+        mock_topic.partitions = {0: mock_partition, 1: mock_partition}
+        mock_metadata.topics = {"test-topic": mock_topic}
+        
+        return mock_metadata
+
+    def create_mock_consumer_groups(self):
+        """Create mock consumer groups for testing."""
+        mock_group = MagicMock()
+        mock_group.group_id = "test-consumer-group"
+        mock_group.is_simple_consumer_group = False
+        mock_group.state = MagicMock()
+        mock_group.state.name = "STABLE"
+        
+        mock_result = MagicMock()
+        mock_result.result.return_value = [mock_group]
+        
+        return mock_result
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_brokers_resource(self, mock_cluster_manager):
+        """Test kafka://brokers resource."""
+        # Mock the cluster manager - mock clusters as MagicMock so .keys() is mockable
+        mock_clusters = MagicMock()
+        mock_clusters.keys.return_value = ["test-cluster-1", "test-cluster-2"]
+        mock_cluster_manager.clusters = mock_clusters
+        
+        # Mock admin clients
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.return_value = self.create_mock_metadata()
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        # Test the resource
+        result_json = await get_brokers_resource()
+        result = json.loads(result_json)
+        
+        # Verify structure
+        assert "brokers" in result
+        assert "timestamp" in result
+        assert isinstance(result["brokers"], dict)
+        
+        # Verify broker data for each cluster
+        for cluster_name in ["test-cluster-1", "test-cluster-2"]:
+            if cluster_name in result["brokers"] and isinstance(result["brokers"][cluster_name], list):
+                broker = result["brokers"][cluster_name][0]
+                assert "broker_id" in broker
+                assert "host" in broker
+                assert "port" in broker
+                assert "cluster" in broker
+                assert broker["cluster"] == cluster_name
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_topics_resource(self, mock_cluster_manager):
+        """Test kafka://topics resource."""
+        # Mock the cluster manager - mock clusters as MagicMock so .keys() is mockable
+        mock_clusters = MagicMock()
+        mock_clusters.keys.return_value = ["test-cluster-1"]
+        mock_cluster_manager.clusters = mock_clusters
+        
+        # Mock admin client
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.return_value = self.create_mock_metadata()
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        # Test the resource
+        result_json = await get_topics_resource()
+        result = json.loads(result_json)
+        
+        # Verify structure
+        assert "topics" in result
+        assert "timestamp" in result
+        assert isinstance(result["topics"], dict)
+        
+        # Verify topic data
+        if "test-cluster-1" in result["topics"] and isinstance(result["topics"]["test-cluster-1"], list):
+            topic = result["topics"]["test-cluster-1"][0]
+            assert "name" in topic
+            assert "partitions" in topic
+            assert "replication_factor" in topic
+            assert "cluster" in topic
+            assert topic["cluster"] == "test-cluster-1"
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_consumer_groups_resource(self, mock_cluster_manager):
+        """Test kafka://consumer-groups resource."""
+        # Mock the cluster manager - mock clusters as MagicMock so .keys() is mockable
+        mock_clusters = MagicMock()
+        mock_clusters.keys.return_value = ["test-cluster-1"]
+        mock_cluster_manager.clusters = mock_clusters
+        
+        # Mock admin client
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_consumer_groups.return_value = self.create_mock_consumer_groups()
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        # Test the resource
+        result_json = await get_consumer_groups_resource()
+        result = json.loads(result_json)
+        
+        # Verify structure
+        assert "consumer_groups" in result
+        assert "timestamp" in result
+        assert isinstance(result["consumer_groups"], dict)
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_get_partitions_resource(self, mock_cluster_manager):
+        """Test kafka://partitions resource."""
+        # Mock the cluster manager - mock clusters as MagicMock so .keys() is mockable
+        mock_clusters = MagicMock()
+        mock_clusters.keys.return_value = ["test-cluster-1"]
+        mock_cluster_manager.clusters = mock_clusters
+        
+        # Mock admin client
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.return_value = self.create_mock_metadata()
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        # Test the resource
+        result_json = await get_partitions_resource()
+        result = json.loads(result_json)
+        
+        # Verify structure
+        assert "partitions" in result
+        assert "timestamp" in result
+        assert isinstance(result["partitions"], dict)
+        
+        # Verify partition data
+        if "test-cluster-1" in result["partitions"] and isinstance(result["partitions"]["test-cluster-1"], list):
+            partition = result["partitions"]["test-cluster-1"][0]
+            assert "topic" in partition
+            assert "partition_id" in partition
+            assert "leader" in partition
+            assert "replicas" in partition
+            assert "cluster" in partition
+            assert partition["cluster"] == "test-cluster-1"
+
+
+class TestNewTools:
+    """Test the new MCP tools that use resources."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.manager = KafkaClusterManager()
+        
+        # Initialize cluster_manager in the imported modules
+        kafka_mcp_tools.set_cluster_manager(self.manager)
+        kafka_mcp_resources.set_cluster_manager(self.manager)
+        
+        # Add test clusters
+        cluster1_config = KafkaClusterConfig(
+            name="cluster1",
+            bootstrap_servers="localhost:9092"
+        )
+        cluster2_config = KafkaClusterConfig(
+            name="cluster2", 
+            bootstrap_servers="localhost:9093"
+        )
+        self.manager.clusters = {
+            "cluster1": cluster1_config,
+            "cluster2": cluster2_config
+        }
+
+    @patch('kafka_mcp_resources.get_brokers_resource')
+    @pytest.mark.asyncio
+    async def test_get_brokers_tool_all_clusters(self, mock_resource):
+        """Test get_brokers tool without cluster filter."""
+        # Mock resource response
+        mock_resource.return_value = json.dumps({
+            "brokers": {
+                "cluster1": [
+                    {"broker_id": 1, "host": "host1", "port": 9092, "cluster": "cluster1"}
+                ],
+                "cluster2": [
+                    {"broker_id": 2, "host": "host2", "port": 9092, "cluster": "cluster2"}
+                ]
+            }
+        })
+        
+        result = await list_brokers()
+        
+        # Should return brokers from all clusters
+        assert len(result) == 2
+        assert result[0]["cluster"] in ["cluster1", "cluster2"]
+        assert result[1]["cluster"] in ["cluster1", "cluster2"]
+
+    @patch('kafka_mcp_resources.get_cluster_brokers_resource')
+    @pytest.mark.asyncio
+    async def test_get_brokers_tool_specific_cluster(self, mock_cluster_resource):
+        """Test get_brokers tool with cluster filter."""
+        # Mock cluster-specific resource response
+        mock_cluster_resource.return_value = json.dumps({
+            "cluster": "cluster1",
+            "brokers": [
+                {"broker_id": 1, "host": "host1", "port": 9092, "cluster": "cluster1"}
+            ]
+        })
+        
+        result = await list_brokers(cluster="cluster1")
+        
+        # Should return only brokers from cluster1
+        assert len(result) == 1
+        assert result[0]["cluster"] == "cluster1"
+
+    @patch('kafka_mcp_resources.get_topics_resource')
+    @pytest.mark.asyncio
+    async def test_get_topics_tool_all_clusters(self, mock_resource):
+        """Test get_topics tool without cluster filter."""
+        # Mock resource response
+        mock_resource.return_value = json.dumps({
+            "topics": {
+                "cluster1": [
+                    {"name": "topic1", "partitions": 3, "cluster": "cluster1"}
+                ],
+                "cluster2": [
+                    {"name": "topic2", "partitions": 6, "cluster": "cluster2"}
+                ]
+            }
+        })
+        
+        result = await list_topics()
+        
+        # Should return topics from all clusters, sorted by name
+        assert len(result) == 2
+        assert result[0]["name"] in ["topic1", "topic2"]
+        assert result[1]["name"] in ["topic1", "topic2"]
+
+    @patch('kafka_mcp_resources.get_cluster_consumer_groups_resource')
+    @pytest.mark.asyncio
+    async def test_get_consumer_groups_tool_specific_cluster(self, mock_cluster_resource):
+        """Test get_consumer_groups tool with cluster filter."""
+        # Mock cluster-specific resource response
+        mock_cluster_resource.return_value = json.dumps({
+            "cluster": "cluster2",
+            "consumer_groups": [
+                {"group_id": "group2", "state": "STABLE", "cluster": "cluster2"}
+            ]
+        })
+        
+        result = await list_consumer_groups(cluster="cluster2")
+        
+        # Should return only groups from cluster2
+        assert len(result) == 1
+        assert result[0]["cluster"] == "cluster2"
+        assert result[0]["group_id"] == "group2"
+
+    @patch('kafka_mcp_resources.get_partitions_resource')
+    @pytest.mark.asyncio
+    async def test_get_partitions_tool_with_topic_filter(self, mock_resource):
+        """Test get_partitions tool with topic filter."""
+        # Mock resource response
+        mock_resource.return_value = json.dumps({
+            "partitions": {
+                "cluster1": [
+                    {"topic": "topic1", "partition_id": 0, "cluster": "cluster1"},
+                    {"topic": "topic1", "partition_id": 1, "cluster": "cluster1"},
+                    {"topic": "topic2", "partition_id": 0, "cluster": "cluster1"}
+                ]
+            }
+        })
+        
+        result = await get_partitions(topic="topic1")
+        
+        # Should return only partitions for topic1
+        assert len(result) == 2
+        for partition in result:
+            assert partition["topic"] == "topic1"
+
+    @patch('kafka_mcp_resources.get_cluster_partitions_resource')
+    @pytest.mark.asyncio
+    async def test_get_partitions_tool_with_cluster_and_topic_filter(self, mock_cluster_resource):
+        """Test get_partitions tool with both cluster and topic filters."""
+        # Mock cluster-specific resource response
+        mock_cluster_resource.return_value = json.dumps({
+            "cluster": "cluster1",
+            "partitions": [
+                {"topic": "topic1", "partition_id": 0, "cluster": "cluster1"},
+                {"topic": "topic2", "partition_id": 0, "cluster": "cluster1"}
+            ]
+        })
+        
+        result = await get_partitions(cluster="cluster1", topic="topic1")
+        
+        # Should return only partitions for topic1 in cluster1
+        assert len(result) == 1
+        assert result[0]["topic"] == "topic1"
+        assert result[0]["cluster"] == "cluster1"
+
+    @patch('kafka_mcp_resources.get_brokers_resource')
+    @pytest.mark.asyncio
+    async def test_get_brokers_tool_nonexistent_cluster(self, mock_resource):
+        """Test get_brokers tool with nonexistent cluster."""
+        # Mock resource response
+        mock_resource.return_value = json.dumps({
+            "brokers": {
+                "cluster1": [
+                    {"broker_id": 1, "host": "host1", "port": 9092, "cluster": "cluster1"}
+                ]
+            }
+        })
+        
+        with pytest.raises(ValueError, match="Cluster 'nonexistent' not found"):
+            await list_brokers(cluster="nonexistent")
+
+    @patch('kafka_mcp_resources.get_brokers_resource')
+    @pytest.mark.asyncio
+    async def test_tools_handle_error_responses(self, mock_resource):
+        """Test that tools handle error responses from resources."""
+        # Mock resource response with error
+        mock_resource.return_value = json.dumps({
+            "brokers": {
+                "cluster1": {
+                    "error": "Connection failed",
+                    "status": "failed"
+                }
+            }
+        })
+        
+        result = await list_brokers()
+        
+        # Should return empty list when all clusters have errors
+        assert len(result) == 0
+
+
+class TestResourceErrorHandling:
+    """Test error handling in resources."""
+
+    @patch('kafka_mcp_resources.cluster_manager')
+    @pytest.mark.asyncio
+    async def test_brokers_resource_connection_error(self, mock_cluster_manager):
+        """Test kafka://brokers resource handles connection errors."""
+        # Mock cluster manager with error - mock clusters as MagicMock so .keys() is mockable
+        mock_clusters = MagicMock()
+        mock_clusters.keys.return_value = ["test-cluster"]
+        mock_cluster_manager.clusters = mock_clusters
+        mock_admin_client = MagicMock()
+        mock_admin_client.list_topics.side_effect = Exception("Connection failed")
+        mock_cluster_manager.get_admin_client.return_value = mock_admin_client
+        
+        result_json = await get_brokers_resource()
+        result = json.loads(result_json)
+        
+        # Should have error information
+        assert "brokers" in result
+        assert "test-cluster" in result["brokers"]
+        assert "error" in result["brokers"]["test-cluster"]
+        assert "status" in result["brokers"]["test-cluster"]
+        assert result["brokers"]["test-cluster"]["status"] == "failed"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"]) 

--- a/tests/test_topic_operations.py
+++ b/tests/test_topic_operations.py
@@ -15,7 +15,7 @@ import pytest
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from kafka_brokers_unified_mcp import (
+from kafka_cluster_manager import (
     KafkaClusterManager, 
     load_cluster_configurations
 )


### PR DESCRIPTION
- Introduce `kafka_cluster_manager.py` for managing Kafka cluster configurations and connections.
- Implement `kafka_mcp_resources.py` to define resources for cluster status, brokers, topics, and consumer groups.
- Create `kafka_mcp_tools.py` for various MCP tools, including health checks and partition analysis.
- Update `Dockerfile` to include new application files.
- Refactor `kafka_brokers_unified_mcp.py` to utilize the new modules and improve code organization.
- Enhance README and documentation to reflect new features and usage.
- Add tests for new resources and tools to ensure functionality and reliability.